### PR TITLE
Give `auto-pr` a ton of love

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /gh-codeowners
 /gh-codeowners.exe
+coverage.out
+coverage.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /gh-codeowners
 /gh-codeowners.exe
-coverage.out
+*.out
 coverage.html

--- a/cmd/auto-pr.go
+++ b/cmd/auto-pr.go
@@ -515,6 +515,8 @@ func getBodyTemplate(cmd *cobra.Command, rootOpts *RootCmdOptions, autoPrOpts *A
 				return err
 			}
 
+			var initialContents = ""
+
 			// Is this the last option that we insert for blank
 			if len(templates) != templateOption {
 				templateFile, err := rootOpts.ReadFile(templates[templateOption])
@@ -532,8 +534,17 @@ func getBodyTemplate(cmd *cobra.Command, rootOpts *RootCmdOptions, autoPrOpts *A
 					return err
 				}
 
-				autoPrOpts.BodyTemplate = builder.String()
+				initialContents = builder.String()
 			}
+
+			var contents string
+			err = rootOpts.AskOne(initialContents, &contents)
+
+			if err != nil {
+				return err
+			}
+
+			autoPrOpts.BodyTemplate = contents
 		}
 	}
 

--- a/cmd/auto-pr.go
+++ b/cmd/auto-pr.go
@@ -433,6 +433,13 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 	// Stdout should be a url to the PR
 	cmd.Printf("PR for %s: %s", data.TeamId, stdOut.String())
 
+	err = createStash(opts)
+
+	if err != nil {
+		cmd.Println("Failed to create stash")
+		return err
+	}
+
 	// TODO: This doesn't work if interactive staging happened
 	// Checkout back to the last branch so we can continue with new teams or leave the user back where they were
 	checkoutOutput, err = opts.GitExec("checkout", "-")
@@ -441,6 +448,13 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		cmd.Println("Could not checkout last branch")
 		cmd.ErrOrStderr().Write(checkoutOutput)
 		return fmt.Errorf("error trying to checkout base branch: %v", err)
+	}
+
+	err = applyStash(opts)
+
+	if err != nil {
+		cmd.Println("Failed to apply stash")
+		return err
 	}
 
 	return nil
@@ -626,6 +640,18 @@ func buildShortNames(teams []string) map[string]string {
 	}
 
 	return output
+}
+
+func createStash(opts *RootCmdOptions) error {
+	// TODO: Make smarter with a custom message
+	_, err := opts.GitExec("stash", "push")
+	return err
+}
+
+func applyStash(opts *RootCmdOptions) error {
+	// TODO: Make smarter and apply the stash this program creates by name
+	_, err := opts.GitExec("stash", "pop")
+	return err
 }
 
 type TemplateData struct {

--- a/cmd/auto-pr.go
+++ b/cmd/auto-pr.go
@@ -282,8 +282,11 @@ Tip: quote templates in your shell, for example '{{ .Name }}'.`,
 			// Track checked out branches so we can help "unique-ify" it for them
 			checkedOutBranches := []string{}
 
-			// TODO: Do this loop with some sort that makes it do it the same way each time
-			for team, files := range prPlan.TeamFiles {
+			teams := slices.Collect(maps.Keys(prPlan.TeamFiles))
+			sort.Strings(teams)
+
+			for _, team := range teams {
+				files := prPlan.TeamFiles[team]
 				err = createPullRequest(cmd, &checkedOutBranches, autoPROpts, opts, &TemplateData{
 					Number:     number,
 					TeamId:     team,

--- a/cmd/auto-pr.go
+++ b/cmd/auto-pr.go
@@ -133,7 +133,7 @@ func (plan *PullRequestPlan) DoInteractiveStagingIfNeeded(team string, opts *Roo
 		return nil
 	}
 
-	return opts.GitExecInt(append([]string{"add", "--interactive"}, filesToStage...)...)
+	return opts.GitExecInt(append([]string{"add", "--patch"}, filesToStage...)...)
 }
 
 func NewPullRequestPlan() *PullRequestPlan {
@@ -434,7 +434,7 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 	// Stdout should be a url to the PR
 	cmd.Printf("PR for %s: %s", data.TeamId, stdOut.String())
 
-	err = createStash(opts)
+	stashed, err := createStash(opts)
 
 	if err != nil {
 		cmd.Println("Failed to create stash")
@@ -449,6 +449,10 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		cmd.Println("Could not checkout last branch")
 		cmd.ErrOrStderr().Write(checkoutOutput)
 		return fmt.Errorf("error trying to checkout base branch: %v", err)
+	}
+
+	if !stashed {
+		return nil
 	}
 
 	err = applyStash(opts)
@@ -643,15 +647,21 @@ func buildShortNames(teams []string) map[string]string {
 	return output
 }
 
-func createStash(opts *RootCmdOptions) error {
+func createStash(opts *RootCmdOptions) (bool, error) {
 	// TODO: Make smarter with a custom message
-	_, err := opts.GitExec("stash", "push")
-	return err
+	stashOutput, err := opts.GitExec("stash", "push")
+
+	if err == nil && string(stashOutput) == "No local changes to save\n" {
+		return false, err
+	}
+
+	return err == nil, err
 }
 
 func applyStash(opts *RootCmdOptions) error {
 	// TODO: Make smarter and apply the stash this program creates by name
 	_, err := opts.GitExec("stash", "pop")
+
 	return err
 }
 
@@ -671,6 +681,7 @@ func (d *TemplateData) Input(name string) (string, error) {
 	existingValue, found := d.inputCache[name]
 
 	if !found {
+		// TODO: Change this to team id
 		val, err := d.prompter.Input(fmt.Sprintf("%s: %s", d.Name, name), "")
 
 		if err != nil {

--- a/cmd/auto-pr.go
+++ b/cmd/auto-pr.go
@@ -104,7 +104,10 @@ func (plan *PullRequestPlan) MoveUnownedFiles(opts *RootCmdOptions) error {
 			}
 
 			for _, selectedIndex := range selectedOptions {
-				// All these should be a team name
+				// "Separate" is not a team – skip it for interactive staging
+				if selectedIndex >= len(teamNames) {
+					continue
+				}
 				selectedTeam := teamNames[selectedIndex]
 
 				existingValue, found := plan.InteractiveStageFiles[selectedTeam]
@@ -162,14 +165,50 @@ func newCmdAutoPR(opts *RootCmdOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "auto-pr",
 		Aliases: []string{"pr"},
-		Short:   "Make many PR's from one changeset",
-		Long: `The commit, branch, and PR template file are all allowed to use a go template strings. Branches are required to
-use a template string that will result in a unique name amongst all teams if one is not given, this will append a incrementing
-number to the branch name. Template strings make use of go text/template using the '{{ .TeamId }}' syntax. In addtion to 'TeamId'
-you may use 'Number' which is an incrementing number for the number of PR's being created, 'Name' which is the team name with 
-common prefixes and suffixes removed, 'Files' which is a slice of the files being added to this PR, 'Promote' is replaced with
-a link to this tool. You can also invoke the '{{ .Input "my_value" }} function. This lets you prompt yourself for a value for
-each team.'`,
+		Short:   "Create one PR per CODEOWNERS team",
+		Long: `Create one pull request per CODEOWNERS team from the files in your working tree.
+
+The branch, commit title, and PR body all use Go text/template syntax. Like
+'gh --template' and Docker's '--format', templates are evaluated against a data
+object. In auto-pr, that object describes the team and files for the PR being
+created.
+
+Available template values:
+  .TeamId   Full CODEOWNERS owner, such as @org/platform
+  .Name     Team name shortened by removing common prefixes and suffixes
+  .Number   1-based PR number for this auto-pr run
+  .Files    Files included in this PR
+  .Promote  Link back to this tool
+
+Available template function:
+  .Input "Label"
+    Prompt for a value while generating a PR. The answer is cached per team, so
+    you can reuse it within the branch, commit, and body templates.
+
+If --body is not provided, auto-pr looks for GitHub pull request templates in
+the repository, lets you choose one, and opens it for editing before creating
+PRs.
+
+Branch names must be unique. If multiple teams render the same branch name,
+auto-pr appends -<number> to later branches automatically.
+
+Tip: quote templates in your shell, for example '{{ .Name }}'.`,
+		Example: `  # Prompt for missing templates and choose a PR body template from the repo
+  gh-codeowners auto-pr
+
+  # Provide branch and commit templates explicitly
+  gh-codeowners auto-pr \
+    --branch 'codeowners/{{ .Name }}' \
+    --commit 'Split changes for {{ .TeamId }}'
+
+  # Reuse prompted input across templates
+  gh-codeowners auto-pr \
+    --branch 'feature/{{ .Input "Ticket" }}-{{ .Name }}' \
+    --commit '{{ .Input "Ticket" }}: changes for {{ .TeamId }}' \
+    --body 'Implements {{ .Input "Ticket" }} for {{ .TeamId }}'
+
+  # Put unowned files in their own PR
+  gh-codeowners auto-pr --unowned-files Separate`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			edittedFilesScanner, err := GetEdittedFilesScanner(cmd, opts)
 
@@ -288,16 +327,26 @@ each team.'`,
 	}
 
 	fl := cmd.Flags()
-	fl.StringVarP(&autoPROpts.CommitTemplate, "commit", "c", "", "The template string to use for each commit")
-	fl.StringVarP(&autoPROpts.BranchTemplate, "branch", "b", "", "The template string to use for each branch that is created")
-	fl.StringVarP(&autoPROpts.UnownedFiles, "unowned-files", "u", "", "What PR to put unowned files onto. `separate` to make their own PR.")
+	fl.StringVarP(&autoPROpts.CommitTemplate, "commit", "c", "", "Go template for each commit title and PR title")
+	fl.StringVarP(&autoPROpts.BranchTemplate, "branch", "b", "", "Go template for each branch name")
+	fl.StringVarP(&autoPROpts.UnownedFiles, "unowned-files", "u", "", "Team name or `Separate` for unowned files")
 	fl.BoolVarP(&autoPROpts.IsDraft, "draft", "d", false, "Mark the pull requests as drafts")
 	fl.BoolVar(&autoPROpts.DryRun, "dry-run", false, "Print details instead of creating the PR. May still push git changes.")
-	fl.StringVar(&autoPROpts.BodyTemplate, "body", "", "The template `file` to use when creating the templated team PR")
-	fl.StringVarP(&autoPROpts.RemoteName, "remote", "r", "", "The remote the PR will be created on")
+	fl.StringVar(&autoPROpts.BodyTemplate, "body", "", "Go template for each PR body")
+	fl.StringVarP(&autoPROpts.RemoteName, "remote", "r", "", "Git remote to push branches to before creating PRs")
 
 	_ = cmd.RegisterFlagCompletionFunc("unowned-files", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// TODO: Do early parse of CODEOWNERS file to help fill in option
+		// Do early read of codeowners file to find all relevant teams
+		teams, err := GetCodeownerTeams(cmd, opts, toComplete)
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		return append(teams, "Separate"), cobra.ShellCompDirectiveDefault
+	})
+
+	_ = cmd.RegisterFlagCompletionFunc("remote", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveError
 	})
 
@@ -321,10 +370,9 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		teamBranch = fmt.Sprintf("%s-%d", teamBranch, data.Number)
 	}
 
-	// Track branch
-	*checkedOutBranches = append(*checkedOutBranches, teamBranch)
-
 	checkoutArgs := []string{"checkout", "-b", teamBranch}
+	localBranchCreated := false
+	commitCreated := false
 
 	// Checkout
 	checkoutOutput, err := opts.GitExec(checkoutArgs...)
@@ -337,6 +385,11 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		cmd.ErrOrStderr().Write(checkoutOutput)
 		return fmt.Errorf("error checking out branch '%s': %v", teamBranch, err)
 	}
+	localBranchCreated = true
+
+	// Track branch only after checkout succeeds so failed branches do not pollute
+	// the uniqueness check for later teams in this run.
+	*checkedOutBranches = append(*checkedOutBranches, teamBranch)
 
 	// Stage files for this team
 	addOutput, err := opts.GitExec(append([]string{"add"}, data.Files...)...)
@@ -346,14 +399,20 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		// 1.
 		cmd.Println("Error doing git add operation")
 		cmd.ErrOrStderr().Write(addOutput)
-		return fmt.Errorf("problem adding files: %v", err)
+		return withRecoveryError(
+			fmt.Errorf("problem adding files: %v", err),
+			recoverFromPreCommitFailure(cmd, opts, teamBranch, localBranchCreated),
+		)
 	}
 
 	// Possibly do interactive staging
 	err = runInteractiveStaging(data.TeamId)
 
 	if err != nil {
-		return fmt.Errorf("issue doing interactive staging: %v", err)
+		return withRecoveryError(
+			fmt.Errorf("issue doing interactive staging: %v", err),
+			recoverFromPreCommitFailure(cmd, opts, teamBranch, localBranchCreated),
+		)
 	}
 
 	teamCommit, err := executeToString("Commit Template", prOpts.CommitTemplate, data)
@@ -373,8 +432,12 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		// 1.
 		cmd.Println("Error doing git commit operation")
 		cmd.ErrOrStderr().Write(commitOutput)
-		return fmt.Errorf("problem committing code for team '%s': %v", data.TeamId, err)
+		return withRecoveryError(
+			fmt.Errorf("problem committing code for team '%s': %v", data.TeamId, err),
+			recoverFromPreCommitFailure(cmd, opts, teamBranch, localBranchCreated),
+		)
 	}
+	commitCreated = true
 
 	// Push branch
 	pushArgs := []string{"push", "--set-upstream", prOpts.RemoteName, teamBranch}
@@ -387,7 +450,10 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		cmd.Printf("Error doing git push operation: %v\n", pushArgs)
 		cmd.Println(err)
 		cmd.ErrOrStderr().Write(pushOutput)
-		return fmt.Errorf("problem pushing to remote")
+		return withRecoveryError(
+			fmt.Errorf("problem pushing to remote; committed changes were left on branch '%s'", teamBranch),
+			recoverFromPostCommitFailure(cmd, opts, teamBranch, localBranchCreated, commitCreated),
+		)
 	}
 
 	file, err := os.CreateTemp(os.TempDir(), "team_pr_body")
@@ -429,13 +495,16 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		cmd.Printf("Problem creating PR with gh CLI: %v\n", args)
 		cmd.OutOrStdout().Write(stdOut.Bytes())
 		cmd.ErrOrStderr().Write(stdErr.Bytes())
-		return fmt.Errorf("error creating PR with GitHub CLI: %v", err)
+		return withRecoveryError(
+			fmt.Errorf("error creating PR with GitHub CLI: %v; branch '%s' was left in place", err, teamBranch),
+			recoverFromPostCommitFailure(cmd, opts, teamBranch, localBranchCreated, commitCreated),
+		)
 	}
 
 	// Stdout should be a url to the PR
 	cmd.Printf("PR for %s: %s", data.TeamId, stdOut.String())
 
-	stashed, err := createStash(opts)
+	stashRef, err := createStash(opts, fmt.Sprintf("gh-codeowners:auto-pr:%s", teamBranch))
 
 	if err != nil {
 		cmd.Println("Failed to create stash")
@@ -452,15 +521,76 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 		return fmt.Errorf("error trying to checkout base branch: %v", err)
 	}
 
-	if !stashed {
+	if stashRef == "" {
 		return nil
 	}
 
-	err = applyStash(opts)
+	err = applyStash(opts, stashRef)
 
 	if err != nil {
 		cmd.Println("Failed to apply stash")
-		return err
+		return fmt.Errorf("failed to apply stash %s: %v", stashRef, err)
+	}
+
+	return nil
+}
+
+func withRecoveryError(originalErr, recoveryErr error) error {
+	if originalErr == nil {
+		return recoveryErr
+	}
+
+	if recoveryErr == nil {
+		return originalErr
+	}
+
+	return fmt.Errorf("%w; recovery failed: %v", originalErr, recoveryErr)
+}
+
+func recoverFromPreCommitFailure(cmd *cobra.Command, opts *RootCmdOptions, teamBranch string, localBranchCreated bool) error {
+	if !localBranchCreated {
+		return nil
+	}
+
+	var recoveryErr error
+
+	unstageOutput, err := opts.GitExec("restore", "--staged", ".")
+	if err != nil {
+		cmd.Println("Could not unstage files while recovering")
+		cmd.ErrOrStderr().Write(unstageOutput)
+		recoveryErr = fmt.Errorf("could not unstage files: %v", err)
+	}
+
+	checkoutErr := checkoutPreviousBranch(cmd, opts)
+	recoveryErr = withRecoveryError(recoveryErr, checkoutErr)
+	if checkoutErr != nil {
+		return recoveryErr
+	}
+
+	deleteOutput, err := opts.GitExec("branch", "-D", teamBranch)
+	if err != nil {
+		cmd.Printf("Could not delete recovery branch '%s'\n", teamBranch)
+		cmd.ErrOrStderr().Write(deleteOutput)
+		return withRecoveryError(recoveryErr, fmt.Errorf("could not delete recovery branch '%s': %v", teamBranch, err))
+	}
+
+	return recoveryErr
+}
+
+func recoverFromPostCommitFailure(cmd *cobra.Command, opts *RootCmdOptions, teamBranch string, localBranchCreated, commitCreated bool) error {
+	if !localBranchCreated || !commitCreated {
+		return nil
+	}
+
+	return checkoutPreviousBranch(cmd, opts)
+}
+
+func checkoutPreviousBranch(cmd *cobra.Command, opts *RootCmdOptions) error {
+	checkoutOutput, err := opts.GitExec("checkout", "-")
+	if err != nil {
+		cmd.Println("Could not checkout last branch")
+		cmd.ErrOrStderr().Write(checkoutOutput)
+		return fmt.Errorf("error trying to checkout base branch: %v", err)
 	}
 
 	return nil
@@ -648,20 +778,42 @@ func buildShortNames(teams []string) map[string]string {
 	return output
 }
 
-func createStash(opts *RootCmdOptions) (bool, error) {
-	// TODO: Make smarter with a custom message
-	stashOutput, err := opts.GitExec("stash", "push")
-
-	if err == nil && string(stashOutput) == "No local changes to save\n" {
-		return false, err
+func createStash(opts *RootCmdOptions, stashMessage string) (string, error) {
+	statusOutput, err := opts.GitExec("status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return "", err
 	}
 
-	return err == nil, err
+	if len(statusOutput) == 0 {
+		return "", nil
+	}
+
+	_, err = opts.GitExec("stash", "push", "--include-untracked", "-m", stashMessage)
+	if err != nil {
+		return "", err
+	}
+
+	stashListOutput, err := opts.GitExec("stash", "list", "--format=%gd\t%s")
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(stashListOutput)), "\n") {
+		if line == "" {
+			continue
+		}
+
+		ref, message, found := strings.Cut(line, "\t")
+		if found && strings.Contains(message, stashMessage) {
+			return ref, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find created stash '%s'", stashMessage)
 }
 
-func applyStash(opts *RootCmdOptions) error {
-	// TODO: Make smarter and apply the stash this program creates by name
-	_, err := opts.GitExec("stash", "pop")
+func applyStash(opts *RootCmdOptions, stashRef string) error {
+	_, err := opts.GitExec("stash", "pop", "--index", stashRef)
 
 	return err
 }

--- a/cmd/auto-pr.go
+++ b/cmd/auto-pr.go
@@ -56,6 +56,7 @@ func (plan *PullRequestPlan) HasUnownedFiles() bool {
 
 func (plan *PullRequestPlan) MoveUnownedFiles(opts *RootCmdOptions) error {
 	teamNames := slices.Collect(maps.Keys(plan.TeamFiles))
+	sort.Strings(teamNames)
 	generalOptions := append(teamNames, "Separate", "Choose for each")
 	generalOptionIndex, err := opts.Prompter.Select(fmt.Sprintf("Choose where to put %d unowned files", len(plan.UnownedFiles)), "", generalOptions)
 

--- a/cmd/auto-pr.go
+++ b/cmd/auto-pr.go
@@ -362,6 +362,7 @@ func createPullRequest(cmd *cobra.Command, checkedOutBranches *[]string, prOpts 
 	}
 
 	// Create commit
+	cmd.Printf("Doing commit for %s", data.TeamId)
 	commitArgs := []string{"commit", "--message", teamCommit}
 
 	commitOutput, err := opts.GitExec(commitArgs...)

--- a/cmd/auto-pr_test.go
+++ b/cmd/auto-pr_test.go
@@ -2,9 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/justindbaur/gh-codeowners/internal"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -283,4 +287,326 @@ func TestMoveUnownedFiles_chooseMultipleTeams(t *testing.T) {
 		"@team-1": {"test-file.txt"},
 		"@team-2": {"test-file.txt"},
 	}, plan.InteractiveStageFiles)
+}
+
+func TestMoveUnownedFiles_selectError(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	opts.Prompter.
+		On("Select", mock.Anything, mock.Anything, mock.Anything).
+		Return(0, fmt.Errorf("terminal closed"))
+
+	plan := NewPullRequestPlan()
+	plan.TeamFiles = map[string][]string{"@team-1": {"one.txt"}}
+	plan.UnownedFiles = []string{"unowned.txt"}
+
+	err := plan.MoveUnownedFiles(toActual(opts))
+	assert.ErrorContains(t, err, "terminal closed")
+}
+
+func TestMoveUnownedFiles_chooseForEachNoItemsSelected(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	// "Choose for each" is the last general option (index 3 for 2 teams).
+	opts.Prompter.
+		On("Select", mock.Anything, mock.Anything, mock.Anything).
+		Return(3, nil)
+	opts.Prompter.
+		On("MultiSelect", mock.Anything, mock.Anything, mock.Anything).
+		Return([]int{}, nil)
+
+	plan := NewPullRequestPlan()
+	plan.TeamFiles = map[string][]string{
+		"@team-1": {"one.txt"},
+		"@team-2": {"two.txt"},
+	}
+	plan.UnownedFiles = []string{"unowned.txt"}
+
+	err := plan.MoveUnownedFiles(toActual(opts))
+	assert.ErrorContains(t, err, "must select at least one action")
+}
+
+func TestMoveUnownedFiles_chooseForEachSeparateWithTeamError(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	opts.Prompter.
+		On("Select", mock.Anything, mock.Anything, mock.Anything).
+		Return(3, nil)
+	// For 2 teams, specificOptions = ["@team-1", "@team-2", "Separate"].
+	// Selecting both @team-1 (0) and Separate (2) together is invalid.
+	opts.Prompter.
+		On("MultiSelect", mock.Anything, mock.Anything, mock.Anything).
+		Return([]int{0, 2}, nil)
+
+	plan := NewPullRequestPlan()
+	plan.TeamFiles = map[string][]string{
+		"@team-1": {"one.txt"},
+		"@team-2": {"two.txt"},
+	}
+	plan.UnownedFiles = []string{"unowned.txt"}
+
+	err := plan.MoveUnownedFiles(toActual(opts))
+	assert.ErrorContains(t, err, "cannot select Separate alongside a team")
+}
+
+func TestMoveUnownedFiles_chooseForEachSeparateOnly(t *testing.T) {
+	// When the user selects only "Separate" in the per-file multi-select, the file
+	// should land in SeparateFiles without any panic (tests the bug-fix guard on the
+	// interactive-staging loop).
+	opts := internal.NewTestRootOpts()
+	opts.Prompter.
+		On("Select", mock.Anything, mock.Anything, mock.Anything).
+		Return(3, nil)
+	// Index 2 = "Separate" (len(teamNames) == 2).
+	opts.Prompter.
+		On("MultiSelect", mock.Anything, mock.Anything, mock.Anything).
+		Return([]int{2}, nil)
+
+	plan := NewPullRequestPlan()
+	plan.TeamFiles = map[string][]string{
+		"@team-1": {"one.txt"},
+		"@team-2": {"two.txt"},
+	}
+	plan.UnownedFiles = []string{"unowned.txt"}
+
+	err := plan.MoveUnownedFiles(toActual(opts))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"unowned.txt"}, plan.SeparateFiles)
+	assert.Empty(t, plan.InteractiveStageFiles)
+}
+
+func TestMoveUnownedFiles_chooseForEachUpdatesExistingTeamEntry(t *testing.T) {
+	// Two unowned files both routed to @team-1 exercises the "found" branch of the
+	// InteractiveStageFiles map update.
+	opts := internal.NewTestRootOpts()
+	opts.Prompter.
+		On("Select", mock.Anything, mock.Anything, mock.Anything).
+		Return(3, nil)
+	opts.Prompter.
+		On("MultiSelect", "What teams should 'first.txt' be put into (can select multiple)",
+			[]string{}, []string{"@team-1", "@team-2", "Separate"}).
+		Return([]int{0}, nil)
+	opts.Prompter.
+		On("MultiSelect", "What teams should 'second.txt' be put into (can select multiple)",
+			[]string{}, []string{"@team-1", "@team-2", "Separate"}).
+		Return([]int{0}, nil)
+
+	plan := NewPullRequestPlan()
+	plan.TeamFiles = map[string][]string{
+		"@team-1": {"one.txt"},
+		"@team-2": {"two.txt"},
+	}
+	plan.UnownedFiles = []string{"first.txt", "second.txt"}
+
+	err := plan.MoveUnownedFiles(toActual(opts))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"first.txt", "second.txt"}, plan.InteractiveStageFiles["@team-1"])
+}
+
+func TestBuildShortNames_singleTeamPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		buildShortNames([]string{"@only-one-team"})
+	})
+}
+
+func newBodyTemplateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("body", "", "")
+	return cmd
+}
+
+func TestGetBodyTemplate_skipsWhenBodyFlagProvided(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	cmd := newBodyTemplateTestCmd()
+	err := cmd.Flags().Set("body", "already set")
+	assert.NoError(t, err)
+
+	autoPrOpts := &AutoPROptions{BodyTemplate: "already set"}
+
+	err = getBodyTemplate(cmd, toActual(opts), autoPrOpts)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "already set", autoPrOpts.BodyTemplate)
+	opts.Mock.AssertNotCalled(t, "GitExec", mock.Anything)
+	opts.Mock.AssertNotCalled(t, "AskOne", mock.Anything, mock.Anything)
+	opts.Prompter.AssertNotCalled(t, "Select", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGetBodyTemplate_noTemplatesFound(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	cmd := newBodyTemplateTestCmd()
+	tempDir := t.TempDir()
+
+	opts.Mock.On("GitExec", []string{"rev-parse", "--show-toplevel"}).
+		Return([]byte(tempDir+"\n"), nil)
+
+	autoPrOpts := &AutoPROptions{}
+
+	err := getBodyTemplate(cmd, toActual(opts), autoPrOpts)
+
+	assert.NoError(t, err)
+	assert.Empty(t, autoPrOpts.BodyTemplate)
+	opts.Mock.AssertNotCalled(t, "AskOne", mock.Anything, mock.Anything)
+	opts.Prompter.AssertNotCalled(t, "Select", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGetBodyTemplate_usesSelectedTemplateContents(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	cmd := newBodyTemplateTestCmd()
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, ".github", "PULL_REQUEST_TEMPLATE.md")
+
+	err := os.MkdirAll(filepath.Dir(templatePath), 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(templatePath, []byte("Template from disk"), 0o644)
+	assert.NoError(t, err)
+
+	opts.Mock.On("GitExec", []string{"rev-parse", "--show-toplevel"}).
+		Return([]byte(tempDir+"\n"), nil)
+	opts.Prompter.On("Select", "Choose a template", mock.Anything, []string{"PULL_REQUEST_TEMPLATE.md", "Start with a blank pull request"}).
+		Return(0, nil)
+	opts.Mock.On("ReadFile", templatePath).Return(&internal.TestFile{
+		Contents: "Template from disk",
+	}, nil)
+	opts.Mock.On("AskOne", "Template from disk", mock.Anything).Run(func(args mock.Arguments) {
+		contents := args.Get(1).(*string)
+		*contents = "Final body"
+	}).Return(nil)
+
+	autoPrOpts := &AutoPROptions{}
+
+	err = getBodyTemplate(cmd, toActual(opts), autoPrOpts)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Final body", autoPrOpts.BodyTemplate)
+}
+
+func TestGetBodyTemplate_blankOptionStartsEmpty(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	cmd := newBodyTemplateTestCmd()
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, ".github", "PULL_REQUEST_TEMPLATE.md")
+
+	err := os.MkdirAll(filepath.Dir(templatePath), 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(templatePath, []byte("Template from disk"), 0o644)
+	assert.NoError(t, err)
+
+	opts.Mock.On("GitExec", []string{"rev-parse", "--show-toplevel"}).
+		Return([]byte(tempDir+"\n"), nil)
+	opts.Prompter.On("Select", "Choose a template", mock.Anything, []string{"PULL_REQUEST_TEMPLATE.md", "Start with a blank pull request"}).
+		Return(1, nil)
+	opts.Mock.On("AskOne", "", mock.Anything).Run(func(args mock.Arguments) {
+		contents := args.Get(1).(*string)
+		*contents = "Body from scratch"
+	}).Return(nil)
+
+	autoPrOpts := &AutoPROptions{}
+
+	err = getBodyTemplate(cmd, toActual(opts), autoPrOpts)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Body from scratch", autoPrOpts.BodyTemplate)
+	opts.Mock.AssertNotCalled(t, "ReadFile", templatePath)
+}
+
+func TestGetBodyTemplate_readFileError(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	cmd := newBodyTemplateTestCmd()
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, ".github", "PULL_REQUEST_TEMPLATE.md")
+
+	err := os.MkdirAll(filepath.Dir(templatePath), 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(templatePath, []byte("Template from disk"), 0o644)
+	assert.NoError(t, err)
+
+	opts.Mock.On("GitExec", []string{"rev-parse", "--show-toplevel"}).
+		Return([]byte(tempDir+"\n"), nil)
+	opts.Prompter.On("Select", "Choose a template", mock.Anything, []string{"PULL_REQUEST_TEMPLATE.md", "Start with a blank pull request"}).
+		Return(0, nil)
+	opts.Mock.On("ReadFile", templatePath).Return(&internal.TestFile{}, fmt.Errorf("permission denied"))
+
+	autoPrOpts := &AutoPROptions{}
+
+	err = getBodyTemplate(cmd, toActual(opts), autoPrOpts)
+
+	assert.ErrorContains(t, err, "permission denied")
+}
+
+func TestGetBodyTemplate_askOneError(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	cmd := newBodyTemplateTestCmd()
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, ".github", "PULL_REQUEST_TEMPLATE.md")
+
+	err := os.MkdirAll(filepath.Dir(templatePath), 0o755)
+	assert.NoError(t, err)
+	err = os.WriteFile(templatePath, []byte("Template from disk"), 0o644)
+	assert.NoError(t, err)
+
+	opts.Mock.On("GitExec", []string{"rev-parse", "--show-toplevel"}).
+		Return([]byte(tempDir+"\n"), nil)
+	opts.Prompter.On("Select", "Choose a template", mock.Anything, []string{"PULL_REQUEST_TEMPLATE.md", "Start with a blank pull request"}).
+		Return(0, nil)
+	opts.Mock.On("ReadFile", templatePath).Return(&internal.TestFile{
+		Contents: "Template from disk",
+	}, nil)
+	opts.Mock.On("AskOne", "Template from disk", mock.Anything).
+		Return(fmt.Errorf("editor crashed"))
+
+	autoPrOpts := &AutoPROptions{}
+
+	err = getBodyTemplate(cmd, toActual(opts), autoPrOpts)
+
+	assert.ErrorContains(t, err, "editor crashed")
+}
+
+func TestCreateStash_noChanges(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	opts.Mock.On("GitExec", []string{"status", "--porcelain", "--untracked-files=all"}).
+		Return([]byte{}, nil)
+
+	stashRef, err := createStash(toActual(opts), "gh-codeowners:auto-pr:test")
+
+	assert.NoError(t, err)
+	assert.Empty(t, stashRef)
+	opts.Mock.AssertNotCalled(t, "GitExec", []string{"stash", "push", "--include-untracked", "-m", "gh-codeowners:auto-pr:test"})
+}
+
+func TestCreateStash_returnsCreatedRef(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	opts.Mock.On("GitExec", []string{"status", "--porcelain", "--untracked-files=all"}).
+		Return([]byte("?? new-file.txt\n"), nil)
+	opts.Mock.On("GitExec", []string{"stash", "push", "--include-untracked", "-m", "gh-codeowners:auto-pr:test"}).
+		Return([]byte{}, nil)
+	opts.Mock.On("GitExec", []string{"stash", "list", "--format=%gd\t%s"}).
+		Return([]byte("stash@{1}\tother-message\nstash@{0}\tgh-codeowners:auto-pr:test\n"), nil)
+
+	stashRef, err := createStash(toActual(opts), "gh-codeowners:auto-pr:test")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "stash@{0}", stashRef)
+}
+
+func TestCreateStash_errorsWhenCreatedRefMissing(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	opts.Mock.On("GitExec", []string{"status", "--porcelain", "--untracked-files=all"}).
+		Return([]byte("?? new-file.txt\n"), nil)
+	opts.Mock.On("GitExec", []string{"stash", "push", "--include-untracked", "-m", "gh-codeowners:auto-pr:test"}).
+		Return([]byte{}, nil)
+	opts.Mock.On("GitExec", []string{"stash", "list", "--format=%gd\t%s"}).
+		Return([]byte("stash@{0}\tother-message\n"), nil)
+
+	stashRef, err := createStash(toActual(opts), "gh-codeowners:auto-pr:test")
+
+	assert.Empty(t, stashRef)
+	assert.ErrorContains(t, err, "could not find created stash")
+}
+
+func TestApplyStash_usesTargetedIndexRestore(t *testing.T) {
+	opts := internal.NewTestRootOpts()
+	opts.Mock.On("GitExec", []string{"stash", "pop", "--index", "stash@{2}"}).
+		Return([]byte{}, nil)
+
+	err := applyStash(toActual(opts), "stash@{2}")
+
+	assert.NoError(t, err)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,20 +10,22 @@ import (
 type Prompter interface {
 	Input(prompt, defaultValue string) (string, error)
 	Select(prompt, defaultValue string, options []string) (int, error)
+	MultiSelect(prompt string, defaultValues, options []string) ([]int, error)
 	Confirm(prompt string, defaultValue bool) (bool, error)
 }
 
-type File struct {
-	Reader io.Reader
-	Close  func() error
+type File interface {
+	Reader() io.Reader
+	Close() error
 }
 
 type RootCmdOptions struct {
 	In            io.Reader
 	Out           io.Writer
 	Err           io.Writer
-	ReadFile      func(filePath string) (*File, error)
+	ReadFile      func(filePath string) (File, error)
 	GitExec       func(arg ...string) ([]byte, error)
+	GitExecInt    func(arg ...string) error
 	GhExec        func(arg ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error)
 	Prompter      Prompter
 	AskOne        func(templateContents string, contents any) error

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -23,7 +23,7 @@ func GetCodeowners(cmd *cobra.Command, opts *RootCmdOptions) (*codeowners.Codeow
 
 		defer file.Close()
 
-		return codeowners.FromReader(file.Reader)
+		return codeowners.FromReader(file.Reader())
 	}
 
 	return nil, fmt.Errorf("could not locate a CODEOWNERS file")

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -31,11 +31,29 @@ func GetCodeowners(cmd *cobra.Command, opts *RootCmdOptions) (*codeowners.Codeow
 
 func GetEdittedFilesScanner(cmd *cobra.Command, opts *RootCmdOptions) (*bufio.Scanner, error) {
 	// TODO: Use flag maybe
-	diffOutput, err := opts.GitExec("--no-pager", "diff", "--name-only")
+	diffOutput, err := opts.GitExec("status", "--untracked-files=all", "--null")
 
 	if err != nil {
 		return nil, fmt.Errorf("error finding files in the working tree")
 	}
 
-	return bufio.NewScanner(bytes.NewReader(diffOutput)), nil
+	scanner := bufio.NewScanner(bytes.NewReader(diffOutput))
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+
+		if i := bytes.IndexByte(data, 0); i >= 0 {
+			// We have a null terminated byte
+			line := data[0:i]
+
+			if s := bytes.LastIndexByte(line, ' '); s >= 0 {
+				return i + 1, line[s+1 : i], nil
+			}
+		}
+
+		return 0, nil, nil
+	})
+
+	return scanner, nil
 }

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -29,6 +29,24 @@ func GetCodeowners(cmd *cobra.Command, opts *RootCmdOptions) (*codeowners.Codeow
 	return nil, fmt.Errorf("could not locate a CODEOWNERS file")
 }
 
+func GetCodeownerTeams(cmd *cobra.Command, opts *RootCmdOptions, query string) ([]string, error) {
+	// TODO: Use flag maybe
+	for _, location := range possibleCodeownersLocations {
+		file, err := opts.ReadFile(location)
+
+		if err != nil {
+			// Not found in that location try the other ones
+			continue
+		}
+
+		defer file.Close()
+
+		return codeowners.ReadTeams(file.Reader(), query), nil
+	}
+
+	return nil, fmt.Errorf("could not locate a CODEOWNERS file")
+}
+
 func GetEdittedFilesScanner(cmd *cobra.Command, opts *RootCmdOptions) (*bufio.Scanner, error) {
 	// TODO: Use flag maybe
 	diffOutput, err := opts.GitExec("status", "--untracked-files=all", "--null")

--- a/codeowners/codeowners.go
+++ b/codeowners/codeowners.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -75,7 +76,7 @@ func FromReader(reader io.Reader) (*Codeowners, error) {
 		if startOfComment == -1 {
 			owners = splitLine[1:]
 		} else {
-			owners = splitLine[1:startOfComment]
+			owners = splitLine[1 : 1+startOfComment]
 		}
 
 		ownerEntries = append(ownerEntries, OwnerEntry{file: splitLine[0], owners: owners, matcher: *regex})
@@ -83,6 +84,54 @@ func FromReader(reader io.Reader) (*Codeowners, error) {
 
 	slices.Reverse(ownerEntries)
 	return &Codeowners{entries: ownerEntries}, nil
+}
+
+func ReadTeams(reader io.Reader, query string) []string {
+	scanner := bufio.NewScanner(reader)
+
+	matchingOwners := map[string]struct{}{}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip comments
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// TODO: More whitespace allowed?
+		splitLine := strings.Split(line, " ")
+
+		if len(splitLine) == 0 {
+			continue
+		}
+
+		if len(splitLine) == 1 {
+			// fmt.Printf("Skipping line '%s' as it is improperly formatted.\n", line)
+			continue
+		}
+
+		// Handle inline comments
+		startOfComment := slices.IndexFunc(splitLine[1:], func(entry string) bool {
+			return strings.HasPrefix(entry, "#")
+		})
+
+		var owners []string
+
+		if startOfComment == -1 {
+			owners = splitLine[1:]
+		} else {
+			owners = splitLine[1 : 1+startOfComment]
+		}
+
+		for _, owner := range owners {
+			if !strings.HasPrefix(owner, query) {
+				continue
+			}
+			matchingOwners[owner] = struct{}{}
+		}
+	}
+
+	return slices.Collect(maps.Keys(matchingOwners))
 }
 
 // For more examples of using go-gh, see:

--- a/codeowners/codeowners_test.go
+++ b/codeowners/codeowners_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFromReader(t *testing.T) {
@@ -16,4 +17,375 @@ test-dir/test @team-1
 	assert.NotNil(t, codeowners)
 
 	assert.True(t, codeowners.IsOwnedBy([]byte("test-dir/test/file.txt"), "@team-1"))
+}
+
+func TestFromReader_patterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		fileName   string
+		wantOwners []string
+	}{
+		// Single-segment (no leading slash) matches at any depth
+		{
+			name:       "single segment extension matches file at root",
+			content:    "*.go @owner",
+			fileName:   "main.go",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "single segment extension matches file in subdirectory",
+			content:    "*.go @owner",
+			fileName:   "cmd/main.go",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "single segment extension matches file deeply nested",
+			content:    "*.go @owner",
+			fileName:   "a/b/c/d/file.go",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "single segment does not match different extension",
+			content:    "*.go @owner",
+			fileName:   "file.txt",
+			wantOwners: []string{},
+		},
+		{
+			name:       "single segment extension does not match similar extension",
+			content:    "*.go @owner",
+			fileName:   "file.gorilla",
+			wantOwners: []string{},
+		},
+		{
+			name:       "single segment directory matches direct child",
+			content:    "test-dir @owner",
+			fileName:   "test-dir/file.txt",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "single segment directory matches nested child",
+			content:    "test-dir @owner",
+			fileName:   "test-dir/sub/nested/file.txt",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "single segment directory matches anywhere in tree",
+			content:    "test-dir @owner",
+			fileName:   "parent/test-dir/file.txt",
+			wantOwners: []string{"@owner"},
+		},
+
+		// Leading slash makes pattern root-relative
+		{
+			name:       "leading slash matches at root",
+			content:    "/docs/file.txt @owner",
+			fileName:   "docs/file.txt",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "leading slash does not match in subdirectory",
+			content:    "/docs/file.txt @owner",
+			fileName:   "other/docs/file.txt",
+			wantOwners: []string{},
+		},
+		{
+			name:       "leading slash directory matches children",
+			content:    "/src @owner",
+			fileName:   "src/main.go",
+			wantOwners: []string{"@owner"},
+		},
+
+		// Trailing slash means directory/**
+		{
+			name:       "trailing slash matches direct children",
+			content:    "docs/ @owner",
+			fileName:   "docs/readme.md",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "trailing slash matches deeply nested children",
+			content:    "src/ @owner",
+			fileName:   "src/a/b/c/d/file.go",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "root trailing slash matches children",
+			content:    "/docs/ @owner",
+			fileName:   "docs/api/reference.md",
+			wantOwners: []string{"@owner"},
+		},
+
+		// Double-star (**) wildcard
+		{
+			name:       "double star at start matches any leading path",
+			content:    "**/logs/*.txt @owner",
+			fileName:   "deep/nested/logs/app.txt",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "double star at start matches file at root",
+			content:    "**/logs/*.txt @owner",
+			fileName:   "logs/app.txt",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "double star at end matches any trailing path",
+			content:    "src/** @owner",
+			fileName:   "src/a/b/c/file.go",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "double star at end matches direct child",
+			content:    "src/** @owner",
+			fileName:   "src/file.go",
+			wantOwners: []string{"@owner"},
+		},
+
+		// Single-star (*) does not cross directory separator
+		{
+			name:       "single star matches within segment",
+			content:    "/src/test_*.go @owner",
+			fileName:   "src/test_foo.go",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "single star does not cross directory separator",
+			content:    "/src/*.go @owner",
+			fileName:   "src/sub/file.go",
+			wantOwners: []string{},
+		},
+
+		// Question mark (?) matches exactly one non-separator character
+		{
+			name:       "question mark matches single character",
+			content:    "/file?.txt @owner",
+			fileName:   "file1.txt",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "question mark does not match multiple characters",
+			content:    "/file?.txt @owner",
+			fileName:   "file12.txt",
+			wantOwners: []string{},
+		},
+		{
+			name:       "question mark does not match path separator",
+			content:    "/dir?/file.txt @owner",
+			fileName:   "di/r/file.txt",
+			wantOwners: []string{},
+		},
+
+		// Multiple owners
+		{
+			name:       "two owners are both returned",
+			content:    "*.go @team-1 @team-2",
+			fileName:   "main.go",
+			wantOwners: []string{"@team-1", "@team-2"},
+		},
+		{
+			name:       "three owners are all returned",
+			content:    "*.go @team-1 @team-2 @team-3",
+			fileName:   "main.go",
+			wantOwners: []string{"@team-1", "@team-2", "@team-3"},
+		},
+
+		// Inline comments are stripped from owners
+		{
+			name:       "inline comment is stripped from owners",
+			content:    "*.go @owner # this is a comment",
+			fileName:   "file.go",
+			wantOwners: []string{"@owner"},
+		},
+		{
+			name:       "inline comment with multiple owners is stripped",
+			content:    "*.go @owner1 @owner2 # ownership details",
+			fileName:   "file.go",
+			wantOwners: []string{"@owner1", "@owner2"},
+		},
+
+		// Last matching rule wins (entries are reversed so last match is checked first)
+		{
+			name:       "later rule overrides earlier rule",
+			content:    "*.go @team-1\nfile.go @team-2",
+			fileName:   "file.go",
+			wantOwners: []string{"@team-2"},
+		},
+		{
+			name:       "earlier rule applies when no later rule matches",
+			content:    "*.go @team-1\nother.go @team-2",
+			fileName:   "file.go",
+			wantOwners: []string{"@team-1"},
+		},
+		{
+			name:       "multiple overrides: last matching rule wins",
+			content:    "*.go @team-1\ndocs/*.go @team-2\ndocs/api.go @team-3",
+			fileName:   "docs/api.go",
+			wantOwners: []string{"@team-3"},
+		},
+
+		// Unowned files
+		{
+			name:       "file with no matching pattern is unowned",
+			content:    "*.go @owner",
+			fileName:   "file.txt",
+			wantOwners: []string{},
+		},
+		{
+			name:       "empty CODEOWNERS means all files unowned",
+			content:    "",
+			fileName:   "any/file.txt",
+			wantOwners: []string{},
+		},
+		{
+			name:       "comment-only CODEOWNERS means all files unowned",
+			content:    "# Just a comment\n# Another comment",
+			fileName:   "file.txt",
+			wantOwners: []string{},
+		},
+
+		// Lines with a pattern but no owners are silently skipped
+		{
+			name:       "pattern with no owners is skipped",
+			content:    "*.go\n*.txt @owner",
+			fileName:   "file.go",
+			wantOwners: []string{},
+		},
+		{
+			name:       "pattern with no owners does not block other rules",
+			content:    "*.go\n*.txt @owner",
+			fileName:   "file.txt",
+			wantOwners: []string{"@owner"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			co, err := FromReader(bytes.NewBufferString(tt.content))
+			require.NoError(t, err)
+			owners := co.FindOwners([]byte(tt.fileName))
+			assert.Equal(t, tt.wantOwners, owners)
+		})
+	}
+}
+
+func TestFromReader_invalidPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "triple star pattern is invalid",
+			content: "*** @owner",
+		},
+		{
+			name:    "triple star in path is invalid",
+			content: "docs/*** @owner",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := FromReader(bytes.NewBufferString(tt.content))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestIsOwnedBy(t *testing.T) {
+	co, err := FromReader(bytes.NewBufferString("*.go @team-1\n*.ts @team-2\n"))
+	require.NoError(t, err)
+
+	assert.True(t, co.IsOwnedBy([]byte("main.go"), "@team-1"))
+	assert.False(t, co.IsOwnedBy([]byte("main.go"), "@team-2"))
+	assert.False(t, co.IsOwnedBy([]byte("main.go"), "@nonexistent"))
+	assert.True(t, co.IsOwnedBy([]byte("app.ts"), "@team-2"))
+	assert.False(t, co.IsOwnedBy([]byte("README.md"), "@team-1"))
+	assert.False(t, co.IsOwnedBy([]byte("README.md"), "@team-2"))
+}
+
+func TestIsOwnedBy_multipleOwners(t *testing.T) {
+	co, err := FromReader(bytes.NewBufferString("*.go @team-1 @team-2\n"))
+	require.NoError(t, err)
+
+	assert.True(t, co.IsOwnedBy([]byte("main.go"), "@team-1"))
+	assert.True(t, co.IsOwnedBy([]byte("main.go"), "@team-2"))
+	assert.False(t, co.IsOwnedBy([]byte("main.go"), "@team-3"))
+}
+
+func TestIsOwnedBy_lastMatchWins(t *testing.T) {
+	// Second rule narrows ownership; IsOwnedBy must reflect the last match
+	co, err := FromReader(bytes.NewBufferString("*.go @team-1\nspecial.go @team-2\n"))
+	require.NoError(t, err)
+
+	// special.go is owned by @team-2, not @team-1
+	assert.False(t, co.IsOwnedBy([]byte("special.go"), "@team-1"))
+	assert.True(t, co.IsOwnedBy([]byte("special.go"), "@team-2"))
+
+	// other .go files are still owned by @team-1
+	assert.True(t, co.IsOwnedBy([]byte("main.go"), "@team-1"))
+	assert.False(t, co.IsOwnedBy([]byte("main.go"), "@team-2"))
+}
+
+func TestReadTeams(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		query     string
+		wantTeams []string
+	}{
+		{
+			name: "filters owners by prefix across multiple lines",
+			content: `*.go @org/backend @org/frontend @other/team
+docs/* @org/docs
+`,
+			query:     "@org/",
+			wantTeams: []string{"@org/backend", "@org/frontend", "@org/docs"},
+		},
+		{
+			name: "deduplicates repeated teams",
+			content: `*.go @org/backend
+*.ts @org/backend @org/frontend
+`,
+			query:     "@org/",
+			wantTeams: []string{"@org/backend", "@org/frontend"},
+		},
+		{
+			name: "strips inline comments before matching owners",
+			content: `*.go @org/backend @org/frontend # primary owners
+`,
+			query:     "@org/",
+			wantTeams: []string{"@org/backend", "@org/frontend"},
+		},
+		{
+			name: "skips comment and malformed lines",
+			content: `# comment
+*.go
+docs/* @org/docs
+`,
+			query:     "@org/",
+			wantTeams: []string{"@org/docs"},
+		},
+		{
+			name: "returns empty when nothing matches prefix",
+			content: `*.go @someone/backend @someone/frontend
+`,
+			query:     "@org/",
+			wantTeams: []string{},
+		},
+		{
+			name: "supports exact prefix matches",
+			content: `*.go @org/backend @org/backend-ops @org/frontend
+`,
+			query:     "@org/backend",
+			wantTeams: []string{"@org/backend", "@org/backend-ops"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teams := ReadTeams(bytes.NewBufferString(tt.content), tt.query)
+			assert.ElementsMatch(t, tt.wantTeams, teams)
+		})
+	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,869 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/justindbaur/gh-codeowners/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// ---------------------------------------------------------------------------
+// report command
+// ---------------------------------------------------------------------------
+
+func TestMainCoreReport_multipleTeams(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"backend/ @org/backend",
+		"frontend/ @org/frontend",
+	})
+
+	testOpts.MockWorkingDirectory([]string{
+		"backend/server.go",
+		"backend/handler.go",
+		"frontend/app.js",
+	})
+
+	err := mainCore(toActual(testOpts), []string{"report"})
+
+	assert.NoError(t, err)
+	out := testOpts.Out.String()
+	// Map iteration is non-deterministic, so check each line individually.
+	assert.Contains(t, out, "@org/backend: 2\n")
+	assert.Contains(t, out, "@org/frontend: 1\n")
+}
+
+func TestMainCoreReport_unownedFiles(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"*.go @org/backend",
+	})
+
+	testOpts.MockWorkingDirectory([]string{
+		"main.go",
+		"README.md",
+		"docs/guide.md",
+	})
+
+	err := mainCore(toActual(testOpts), []string{"report"})
+
+	assert.NoError(t, err)
+	out := testOpts.Out.String()
+	assert.Contains(t, out, "@org/backend: 1\n")
+	assert.Contains(t, out, "Files that are unowned: 2\n")
+}
+
+func TestMainCoreReport_multipleOwnersForFile(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"shared/ @org/team-a @org/team-b",
+	})
+
+	testOpts.MockWorkingDirectory([]string{
+		"shared/utils.go",
+	})
+
+	err := mainCore(toActual(testOpts), []string{"report"})
+
+	assert.NoError(t, err)
+	out := testOpts.Out.String()
+	// Files with multiple owners are reported individually rather than counted.
+	assert.Contains(t, out, "File 'shared/utils.go' is owned by multiple teams @org/team-a, @org/team-b")
+	// They should NOT appear in the per-owner count summary.
+	assert.NotContains(t, out, "@org/team-a:")
+	assert.NotContains(t, out, "@org/team-b:")
+}
+
+func TestMainCoreReport_emptyWorkingTree(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"*.go @org/backend",
+	})
+
+	testOpts.MockWorkingDirectory([]string{})
+
+	err := mainCore(toActual(testOpts), []string{"report"})
+
+	assert.NoError(t, err)
+	assert.Empty(t, testOpts.Out.String())
+}
+
+func TestMainCoreReport_missingCodeowners(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	// All three candidate locations fail.
+	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").Return(&internal.TestFile{}, fmt.Errorf("not found"))
+	testOpts.Mock.On("ReadFile", "CODEOWNERS").Return(&internal.TestFile{}, fmt.Errorf("not found"))
+	testOpts.Mock.On("ReadFile", "docs/CODEOWNERS").Return(&internal.TestFile{}, fmt.Errorf("not found"))
+
+	testOpts.MockWorkingDirectory([]string{"main.go"})
+
+	err := mainCore(toActual(testOpts), []string{"report"})
+
+	assert.ErrorContains(t, err, "could not locate a CODEOWNERS file")
+}
+
+func TestMainCoreReport_codeownersInRoot(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	// .github/CODEOWNERS is missing; fall through to root CODEOWNERS.
+	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").Return(&internal.TestFile{}, fmt.Errorf("not found"))
+	testOpts.Mock.On("ReadFile", "CODEOWNERS").Return(&internal.TestFile{
+		Contents: "*.go @org/backend\n",
+	}, nil)
+
+	testOpts.MockWorkingDirectory([]string{"main.go"})
+
+	err := mainCore(toActual(testOpts), []string{"report"})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "@org/backend: 1\n", testOpts.Out.String())
+}
+
+func TestMainCoreReport_codeownersInDocs(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	// Neither .github/ nor root has a CODEOWNERS; fall through to docs/.
+	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").Return(&internal.TestFile{}, fmt.Errorf("not found"))
+	testOpts.Mock.On("ReadFile", "CODEOWNERS").Return(&internal.TestFile{}, fmt.Errorf("not found"))
+	testOpts.Mock.On("ReadFile", "docs/CODEOWNERS").Return(&internal.TestFile{
+		Contents: "*.go @org/backend\n",
+	}, nil)
+
+	testOpts.MockWorkingDirectory([]string{"main.go"})
+
+	err := mainCore(toActual(testOpts), []string{"report"})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "@org/backend: 1\n", testOpts.Out.String())
+}
+
+func TestMainCoreReport_mixedOwnedAndUnowned(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"*.go @org/backend",
+		"*.ts @org/frontend",
+	})
+
+	testOpts.MockWorkingDirectory([]string{
+		"main.go",
+		"app.ts",
+		"README.md",  // unowned
+		"schema.sql", // unowned
+	})
+
+	err := mainCore(toActual(testOpts), []string{"report"})
+
+	assert.NoError(t, err)
+	out := testOpts.Out.String()
+	assert.Contains(t, out, "@org/backend: 1\n")
+	assert.Contains(t, out, "@org/frontend: 1\n")
+	assert.Contains(t, out, "Files that are unowned: 2\n")
+}
+
+// ---------------------------------------------------------------------------
+// stage command
+// ---------------------------------------------------------------------------
+
+func TestMainCoreStage_multipleFiles(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"*.go @org/backend",
+		"*.js @org/frontend",
+	})
+
+	testOpts.MockWorkingDirectory([]string{
+		"main.go",
+		"server.go",
+		"app.js", // owned by a different team
+	})
+
+	testOpts.Mock.On("GitExec", []string{"add", "main.go"}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"add", "server.go"}).Return([]byte{}, nil)
+
+	err := mainCore(toActual(testOpts), []string{"stage", "@org/backend"})
+
+	assert.NoError(t, err)
+	out := testOpts.Out.String()
+	assert.Contains(t, out, "Staged: main.go\n")
+	assert.Contains(t, out, "Staged: server.go\n")
+	assert.NotContains(t, out, "app.js")
+}
+
+func TestMainCoreStage_noMatchingTeam(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"*.go @org/backend",
+	})
+
+	testOpts.MockWorkingDirectory([]string{
+		"main.go",
+	})
+
+	err := mainCore(toActual(testOpts), []string{"stage", "@org/nonexistent"})
+
+	assert.ErrorContains(t, err, "did not find any files owned by '@org/nonexistent'")
+}
+
+func TestMainCoreStage_missingArgument(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	err := mainCore(toActual(testOpts), []string{"stage"})
+
+	assert.ErrorContains(t, err, "required team argument missing")
+}
+
+func TestMainCoreStage_gitAddError(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"*.go @org/backend",
+	})
+
+	testOpts.MockWorkingDirectory([]string{
+		"main.go",
+	})
+
+	testOpts.Mock.On("GitExec", []string{"add", "main.go"}).
+		Return([]byte{}, fmt.Errorf("permission denied"))
+
+	err := mainCore(toActual(testOpts), []string{"stage", "@org/backend"})
+
+	assert.ErrorContains(t, err, "failed to stage 'main.go'")
+	assert.ErrorContains(t, err, "permission denied")
+}
+
+func TestMainCoreStage_multipleOwnerFile(t *testing.T) {
+	// A file with two owners should be staged when targeting either owner.
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{
+		"shared/ @org/team-a @org/team-b",
+	})
+
+	testOpts.MockWorkingDirectory([]string{
+		"shared/util.go",
+	})
+
+	testOpts.Mock.On("GitExec", []string{"add", "shared/util.go"}).Return([]byte{}, nil)
+
+	err := mainCore(toActual(testOpts), []string{"stage", "@org/team-b"})
+
+	assert.NoError(t, err)
+	assert.Contains(t, testOpts.Out.String(), "Staged: shared/util.go\n")
+}
+
+// ---------------------------------------------------------------------------
+// auto-pr command
+// ---------------------------------------------------------------------------
+
+func TestMainCoreAutoPR_noFilesToPR(t *testing.T) {
+	// When the working tree is empty there is nothing to make PRs for.
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{"*.go @org/backend"})
+	testOpts.MockWorkingDirectory([]string{})
+
+	err := mainCore(toActual(testOpts), []string{"auto-pr"})
+
+	assert.ErrorContains(t, err, "there are no files to make PR's for")
+}
+
+func TestMainCoreAutoPR_singleTeamError(t *testing.T) {
+	// auto-pr requires at least two teams; a single team should return an error.
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{"*.go @org/backend"})
+	testOpts.MockWorkingDirectory([]string{"main.go"})
+
+	err := mainCore(toActual(testOpts), []string{"auto-pr"})
+
+	assert.ErrorContains(t, err, "only one PR would be made")
+}
+
+func TestMainCoreAutoPR_dryRun(t *testing.T) {
+	// With --dry-run, GhExec should be called with --dry-run=true.
+	opts := setupAutoPRTest("dir-1 @team-1\ndir-2 @team-2\n", "dir-1/test.txt\ndir-2/test.txt")
+	opts.MockTemplateHole("@team-1", "Team Name", "one")
+	opts.MockTemplateHole("@team-2", "Team Name", "two")
+
+	err := mainCore(toActual(opts), []string{
+		"auto-pr", "--dry-run",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.NoError(t, err)
+
+	// Verify GhExec was called twice (once per team) and always with --dry-run=true.
+	ghCalls := filterCalls(opts, "GhExec")
+	assert.Len(t, ghCalls, 2, "expected two GhExec calls (one per team PR)")
+	for _, args := range ghCalls {
+		assert.Contains(t, args, "--dry-run=true", "expected --dry-run=true in GhExec args")
+		assert.Contains(t, args, "--draft=false", "dry-run should not imply draft")
+	}
+}
+
+func TestMainCoreAutoPR_draft(t *testing.T) {
+	// With --draft, GhExec should be called with --draft=true.
+	opts := setupAutoPRTest("dir-1 @team-1\ndir-2 @team-2\n", "dir-1/test.txt\ndir-2/test.txt")
+	opts.MockTemplateHole("@team-1", "Team Name", "one")
+	opts.MockTemplateHole("@team-2", "Team Name", "two")
+
+	err := mainCore(toActual(opts), []string{
+		"auto-pr", "--draft",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.NoError(t, err)
+
+	ghCalls := filterCalls(opts, "GhExec")
+	assert.Len(t, ghCalls, 2, "expected two GhExec calls (one per team PR)")
+	for _, args := range ghCalls {
+		assert.Contains(t, args, "--draft=true", "expected --draft=true in GhExec args")
+		assert.Contains(t, args, "--dry-run=false", "draft should not imply dry-run")
+	}
+}
+
+func TestMainCoreAutoPR_prAlias(t *testing.T) {
+	// The "pr" alias should behave the same as "auto-pr".
+	testOpts := internal.NewTestRootOpts()
+
+	testOpts.MockCodeowners([]string{"*.go @org/backend"})
+	testOpts.MockWorkingDirectory([]string{"main.go"})
+
+	// With only one team this will fail, but the alias must be recognised
+	// (not "unknown command").
+	err := mainCore(toActual(testOpts), []string{"pr"})
+
+	assert.ErrorContains(t, err, "only one PR would be made")
+}
+
+// filterCalls returns the []string arguments for every recorded call to
+// methodName on testOpts.Mock.
+func filterCalls(testOpts *internal.TestRootCmdOptions, methodName string) [][]string {
+	var result [][]string
+	for _, call := range testOpts.Mock.Calls {
+		if call.Method != methodName {
+			continue
+		}
+		if args, ok := call.Arguments.Get(0).([]string); ok {
+			result = append(result, args)
+		}
+	}
+	return result
+}
+
+func hasCall(calls [][]string, want []string) bool {
+	for _, call := range calls {
+		if slices.Equal(call, want) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasBranchDeleteCall(calls [][]string) bool {
+	for _, call := range calls {
+		if len(call) == 3 && call[0] == "branch" && call[1] == "-D" && strings.HasPrefix(call[2], "branch/") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// auto-pr: template and remote-name error paths
+// ---------------------------------------------------------------------------
+
+func TestMainCoreAutoPR_emptyBranchTemplate(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+	testOpts.MockCodeowners([]string{"dir-1 @team-1", "dir-2 @team-2"})
+	testOpts.MockWorkingDirectory([]string{"dir-1/file.txt", "dir-2/file.txt"})
+
+	testOpts.Prompter.On("Input", "What branch template do you want?", "").Return("", nil)
+
+	err := mainCore(toActual(testOpts), []string{"auto-pr", "--commit", "commit-{{ .Name }}"})
+
+	assert.ErrorContains(t, err, "branch template is required")
+}
+
+func TestMainCoreAutoPR_emptyCommitTemplate(t *testing.T) {
+	testOpts := internal.NewTestRootOpts()
+	testOpts.MockCodeowners([]string{"dir-1 @team-1", "dir-2 @team-2"})
+	testOpts.MockWorkingDirectory([]string{"dir-1/file.txt", "dir-2/file.txt"})
+
+	testOpts.Prompter.On("Input", "What branch template do you want?", "").Return("branch/{{ .Name }}", nil)
+	testOpts.Prompter.On("Input", "What commit/PR title template do you want?", "Files for {{ .TeamId }}").Return("", nil)
+
+	err := mainCore(toActual(testOpts), []string{"auto-pr"})
+
+	assert.ErrorContains(t, err, "commit template is required")
+}
+
+func TestMainCoreAutoPR_getRemoteNameError(t *testing.T) {
+	testOpts := newAutoPRBaseTestNoRemote(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+	testOpts.Mock.On("GetRemoteName").Return("", fmt.Errorf("no remotes configured"))
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "could not determine remote name")
+}
+
+// ---------------------------------------------------------------------------
+// auto-pr: createPullRequest error paths
+// ---------------------------------------------------------------------------
+
+// newAutoPRBaseTest provides the minimum mocks to reach createPullRequest
+// without any catch-all git/gh handlers.  Each test adds precise expectations.
+func newAutoPRBaseTest(t *testing.T, codeownersContent, workingTree string) *internal.TestRootCmdOptions {
+	t.Helper()
+	testOpts := internal.NewTestRootOpts()
+	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").
+		Return(&internal.TestFile{Contents: codeownersContent}, nil)
+	testOpts.MockWorkingDirectory(strings.Split(workingTree, "\n"))
+	tempDir := t.TempDir()
+	testOpts.Mock.On("GitExec", []string{"rev-parse", "--show-toplevel"}).
+		Return([]byte(tempDir+"\n"), nil)
+	testOpts.Mock.On("GetRemoteName").Return("origin", nil)
+	return testOpts
+}
+
+// newAutoPRBaseTestNoRemote is like newAutoPRBaseTest but does NOT register
+// GetRemoteName — callers set up their own remote-name mock.
+func newAutoPRBaseTestNoRemote(t *testing.T, codeownersContent, workingTree string) *internal.TestRootCmdOptions {
+	t.Helper()
+	testOpts := internal.NewTestRootOpts()
+	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").
+		Return(&internal.TestFile{Contents: codeownersContent}, nil)
+	testOpts.MockWorkingDirectory(strings.Split(workingTree, "\n"))
+	tempDir := t.TempDir()
+	testOpts.Mock.On("GitExec", []string{"rev-parse", "--show-toplevel"}).
+		Return([]byte(tempDir+"\n"), nil)
+	return testOpts
+}
+
+func TestMainCoreAutoPR_gitCheckoutError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, fmt.Errorf("branch already exists"))
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "error checking out branch")
+}
+
+func TestMainCoreAutoPR_gitAddError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, fmt.Errorf("path does not exist"))
+	testOpts.Mock.On("GitExec", []string{"restore", "--staged", "."}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "branch" && args[1] == "-D" && strings.HasPrefix(args[2], "branch/")
+	})).Return([]byte{}, nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "problem adding files")
+	gitCalls := filterCalls(testOpts, "GitExec")
+	assert.True(t, hasCall(gitCalls, []string{"restore", "--staged", "."}))
+	assert.True(t, hasCall(gitCalls, []string{"checkout", "-"}))
+	assert.True(t, hasBranchDeleteCall(gitCalls))
+}
+
+func TestMainCoreAutoPR_interactiveStagingError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt\nextra.txt")
+	testOpts.Prompter.On("Select", "Choose where to put 1 unowned files", "", mock.Anything).
+		Return(3, nil)
+	testOpts.Prompter.On("MultiSelect", mock.Anything, []string{}, []string{"@team-1", "@team-2", "Separate"}).
+		Return([]int{0, 1}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExecInt", mock.Anything).Return(fmt.Errorf("patch failed"))
+	testOpts.Mock.On("GitExec", []string{"restore", "--staged", "."}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "branch" && args[1] == "-D" && strings.HasPrefix(args[2], "branch/")
+	})).Return([]byte{}, nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "issue doing interactive staging")
+	gitCalls := filterCalls(testOpts, "GitExec")
+	assert.True(t, hasCall(gitCalls, []string{"restore", "--staged", "."}))
+	assert.True(t, hasCall(gitCalls, []string{"checkout", "-"}))
+	assert.True(t, hasBranchDeleteCall(gitCalls))
+}
+
+func TestMainCoreAutoPR_gitCommitError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "commit"
+	})).Return([]byte{}, fmt.Errorf("nothing to commit"))
+	testOpts.Mock.On("GitExec", []string{"restore", "--staged", "."}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "branch" && args[1] == "-D" && strings.HasPrefix(args[2], "branch/")
+	})).Return([]byte{}, nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "problem committing code")
+	gitCalls := filterCalls(testOpts, "GitExec")
+	assert.True(t, hasCall(gitCalls, []string{"restore", "--staged", "."}))
+	assert.True(t, hasCall(gitCalls, []string{"checkout", "-"}))
+	assert.True(t, hasBranchDeleteCall(gitCalls))
+}
+
+func TestMainCoreAutoPR_gitPushError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "commit"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "push"
+	})).Return([]byte{}, fmt.Errorf("remote rejected"))
+	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "problem pushing to remote")
+	assert.Contains(t, err.Error(), "committed changes were left on branch 'branch/")
+	gitCalls := filterCalls(testOpts, "GitExec")
+	assert.True(t, hasCall(gitCalls, []string{"checkout", "-"}))
+	assert.False(t, hasBranchDeleteCall(gitCalls))
+}
+
+func TestMainCoreAutoPR_ghPrCreateError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "commit"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "push"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, nil)
+
+	testOpts.Mock.On("GhExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) > 1 && args[0] == "pr" && args[1] == "new"
+	})).Return(*newBuf(""), *newBuf("rate limit exceeded"), fmt.Errorf("gh cli error"))
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "error creating PR with GitHub CLI")
+	assert.Contains(t, err.Error(), "branch 'branch/")
+	assert.ErrorContains(t, err, "was left in place")
+	assert.True(t, hasCall(filterCalls(testOpts, "GitExec"), []string{"checkout", "-"}))
+}
+
+func TestMainCoreAutoPR_addRecoveryCheckoutFailure(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, fmt.Errorf("path does not exist"))
+	testOpts.Mock.On("GitExec", []string{"restore", "--staged", "."}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, fmt.Errorf("cannot switch branches"))
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "problem adding files")
+	assert.ErrorContains(t, err, "recovery failed")
+	assert.ErrorContains(t, err, "error trying to checkout base branch")
+}
+
+// ---------------------------------------------------------------------------
+// auto-pr: non-unique branch names and separate-files PR
+// ---------------------------------------------------------------------------
+
+func TestMainCoreAutoPR_nonUniqueBranchAppended(t *testing.T) {
+	// When the branch template is static (no team-specific part), both teams would
+	// produce the same branch name.  The second one should get a number appended.
+	opts := setupAutoPRTest("dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+
+	err := mainCore(toActual(opts), []string{
+		"auto-pr",
+		"--commit", "commit-static",
+		"--branch", "branch-static",
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, opts.Out.String(), "is not unique, adding incrementing number")
+}
+
+func TestMainCoreAutoPR_separatePRForUnownedFiles(t *testing.T) {
+	// Unowned files routed to "Separate" should result in a third PR being created.
+	opts := setupAutoPRTest(
+		"dir-1 @team-1\ndir-2 @team-2\n",
+		"dir-1/file.txt\ndir-2/file.txt\nunowned.txt",
+	)
+
+	// Route the unowned file to Separate (index 2 for 2 sorted teams).
+	opts.Prompter.On("Select", "Choose where to put 1 unowned files", "", mock.Anything).
+		Return(2, nil)
+
+	err := mainCore(toActual(opts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.NoError(t, err)
+	// Two team PRs + one separate PR.
+	assert.Len(t, filterCalls(opts, "GhExec"), 3)
+}
+
+func TestMainCoreAutoPR_gitStashPushError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "commit"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "push"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"status", "--porcelain", "--untracked-files=all"}).
+		Return([]byte("?? remaining.txt\n"), nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 5 && args[0] == "stash" && args[1] == "push" && args[2] == "--include-untracked" && args[3] == "-m" && strings.HasPrefix(args[4], "gh-codeowners:auto-pr:branch/")
+	})).
+		Return([]byte{}, fmt.Errorf("stash failed"))
+	testOpts.Mock.On("GhExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) > 1 && args[0] == "pr" && args[1] == "new"
+	})).Return(*newBuf("https://example/pr/1"), *newBuf(""), nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "stash failed")
+}
+
+func TestMainCoreAutoPR_checkoutBackError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "commit"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "push"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"status", "--porcelain", "--untracked-files=all"}).
+		Return([]byte("?? remaining.txt\n"), nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 5 && args[0] == "stash" && args[1] == "push" && args[2] == "--include-untracked" && args[3] == "-m" && strings.HasPrefix(args[4], "gh-codeowners:auto-pr:branch/")
+	})).
+		Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"stash", "list", "--format=%gd\t%s"}).
+		Return([]byte("stash@{1}\tgh-codeowners:auto-pr:branch/1\nstash@{0}\tgh-codeowners:auto-pr:branch/2\n"), nil)
+	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, fmt.Errorf("cannot switch branches"))
+	testOpts.Mock.On("GhExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) > 1 && args[0] == "pr" && args[1] == "new"
+	})).Return(*newBuf("https://example/pr/1"), *newBuf(""), nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "error trying to checkout base branch")
+}
+
+func TestMainCoreAutoPR_stashPopError(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 3 && args[0] == "checkout" && args[1] == "-b"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "add"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "commit"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "push"
+	})).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"status", "--porcelain", "--untracked-files=all"}).
+		Return([]byte("?? remaining.txt\n"), nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 5 && args[0] == "stash" && args[1] == "push" && args[2] == "--include-untracked" && args[3] == "-m" && strings.HasPrefix(args[4], "gh-codeowners:auto-pr:branch/")
+	})).
+		Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", []string{"stash", "list", "--format=%gd\t%s"}).
+		Return([]byte("stash@{1}\tgh-codeowners:auto-pr:branch/1\nstash@{0}\tgh-codeowners:auto-pr:branch/2\n"), nil)
+	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, nil)
+	testOpts.Mock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) == 4 && args[0] == "stash" && args[1] == "pop" && args[2] == "--index" && (args[3] == "stash@{0}" || args[3] == "stash@{1}")
+	})).
+		Return([]byte{}, fmt.Errorf("conflict while applying stash"))
+	testOpts.Mock.On("GhExec", mock.MatchedBy(func(args []string) bool {
+		return len(args) > 1 && args[0] == "pr" && args[1] == "new"
+	})).Return(*newBuf("https://example/pr/1"), *newBuf(""), nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "branch/{{ .Name }}",
+	})
+
+	assert.ErrorContains(t, err, "failed to apply stash stash@{")
+}
+
+// ---------------------------------------------------------------------------
+// auto-pr: template parsing/execution errors
+// ---------------------------------------------------------------------------
+
+func TestMainCoreAutoPR_invalidBranchTemplate(t *testing.T) {
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+	testOpts.Mock.On("GitExec", mock.Anything).Return([]byte{}, nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		"--commit", "commit-{{ .Name }}",
+		"--branch", "{{ invalid template",
+	})
+
+	assert.ErrorContains(t, err, "error while formatting branch template")
+}
+
+func TestMainCoreAutoPR_templateInputPromptError(t *testing.T) {
+	// When the branch template calls .Input and the prompter returns an error,
+	// createPullRequest should surface it.
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+	testOpts.Mock.On("GitExec", mock.Anything).Return([]byte{}, nil)
+
+	// Short names for [@team-1, @team-2] are "1" and "2".
+	testOpts.Prompter.On("Input", mock.MatchedBy(func(s string) bool {
+		return strings.HasSuffix(s, ": PR Name")
+	}), "").Return("", fmt.Errorf("user cancelled"))
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		`--branch`, `branch/{{ .Input "PR Name" }}`,
+		`--commit`, `commit/{{ .Name }}`,
+	})
+
+	assert.ErrorContains(t, err, "error while formatting branch template")
+}
+
+func TestMainCoreAutoPR_templateInputEmptyValue(t *testing.T) {
+	// When the user provides an empty string for a template input, an error
+	// should be returned.
+	testOpts := newAutoPRBaseTest(t, "dir-1 @team-1\ndir-2 @team-2\n", "dir-1/file.txt\ndir-2/file.txt")
+	testOpts.Mock.On("GitExec", mock.Anything).Return([]byte{}, nil)
+
+	testOpts.Prompter.On("Input", mock.MatchedBy(func(s string) bool {
+		return strings.HasSuffix(s, ": PR Name")
+	}), "").Return("", nil)
+
+	err := mainCore(toActual(testOpts), []string{
+		"auto-pr",
+		`--branch`, `branch/{{ .Input "PR Name" }}`,
+		`--commit`, `commit/{{ .Name }}`,
+	})
+
+	assert.ErrorContains(t, err, "value not supplied")
+}
+
+// newBuf is a small helper to create a bytes.Buffer pointer from a string,
+// used when constructing GhExec return values.
+func newBuf(s string) *bytes.Buffer {
+	b := bytes.NewBufferString(s)
+	return b
+}

--- a/internal/test.go
+++ b/internal/test.go
@@ -1,0 +1,81 @@
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockPrompter struct{ mock.Mock }
+
+func (p *MockPrompter) Input(prompt, defaultValue string) (string, error) {
+	args := p.Called(prompt, defaultValue)
+	return args.String(0), args.Error(1)
+}
+
+func (p *MockPrompter) Select(prompt, defaultValue string, options []string) (int, error) {
+	args := p.Called(prompt, defaultValue, options)
+	return args.Int(0), args.Error(1)
+}
+
+func (p *MockPrompter) MultiSelect(prompt string, defaultValues, options []string) ([]int, error) {
+	args := p.Called(prompt, defaultValues, options)
+	return args.Get(0).([]int), args.Error(1)
+}
+
+func (p *MockPrompter) Confirm(prompt string, defaultValue bool) (bool, error) {
+	args := p.Called(prompt, defaultValue)
+	return args.Bool(0), args.Error(1)
+}
+
+func NewMockPrompter() *MockPrompter {
+	return &MockPrompter{}
+}
+
+type TestRootCmdOptions struct {
+	Mock     *mock.Mock
+	Prompter *MockPrompter
+	In       *bytes.Buffer
+	Out      *bytes.Buffer
+	Err      *bytes.Buffer
+}
+
+type TestFile struct {
+	Contents string
+}
+
+func (file *TestFile) Reader() io.Reader {
+	return bytes.NewBufferString(file.Contents)
+}
+
+func (file *TestFile) Close() error {
+	return nil
+}
+
+func (testOpts *TestRootCmdOptions) MockTemplateHole(team string, name string, value string) *mock.Call {
+	return testOpts.Prompter.Mock.On("Input", fmt.Sprintf("%s: %s", team, name), "").Return(value, nil)
+}
+
+func (testOpts *TestRootCmdOptions) MockCodeowners(codeownersContent []string) {
+	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").
+		Return(&TestFile{strings.Join(codeownersContent, "\n")}, nil)
+}
+
+func (testOpts *TestRootCmdOptions) MockWorkingDirectory(files []string) {
+	testOpts.Mock.
+		On("GitExec", []string{"--no-pager", "diff", "--name-only"}).
+		Return([]byte(strings.Join(files, "\n")), nil)
+}
+
+func NewTestRootOpts() *TestRootCmdOptions {
+	return &TestRootCmdOptions{
+		In:       bytes.NewBuffer([]byte{}),
+		Out:      bytes.NewBuffer([]byte{}),
+		Err:      bytes.NewBuffer([]byte{}),
+		Mock:     &mock.Mock{},
+		Prompter: NewMockPrompter(),
+	}
+}

--- a/internal/test.go
+++ b/internal/test.go
@@ -65,9 +65,15 @@ func (testOpts *TestRootCmdOptions) MockCodeowners(codeownersContent []string) {
 }
 
 func (testOpts *TestRootCmdOptions) MockWorkingDirectory(files []string) {
+	newFiles := make([]string, len(files))
+
+	for i, file := range files {
+		newFiles[i] = fmt.Sprintf("?? %s", file)
+	}
+
 	testOpts.Mock.
-		On("GitExec", []string{"--no-pager", "diff", "--name-only"}).
-		Return([]byte(strings.Join(files, "\n")), nil)
+		On("GitExec", []string{"status", "--untracked-files=all", "--null"}).
+		Return(append([]byte(strings.Join(newFiles, string(byte(0)))), byte(0)), nil)
 }
 
 func NewTestRootOpts() *TestRootCmdOptions {

--- a/main.go
+++ b/main.go
@@ -19,15 +19,15 @@ import (
 )
 
 type RealFile struct {
-	*os.File
+	innerFile *os.File
 }
 
 func (file *RealFile) Reader() io.Reader {
-	return file
+	return file.innerFile
 }
 
 func (file *RealFile) Close() error {
-	return file.Close()
+	return file.innerFile.Close()
 }
 
 var remoteRE = regexp.MustCompile(`(.+)\s+(.+)\s+\((push|fetch)\)`)
@@ -79,7 +79,7 @@ func main() {
 				return
 			}
 
-			return &RealFile{actualFile}, nil
+			return &RealFile{innerFile: actualFile}, nil
 		},
 		GetRemoteName: func() (string, error) {
 			remoteOutput, err := exec.Command(gitBin, "remote", "-v").Output()

--- a/main_test.go
+++ b/main_test.go
@@ -218,3 +218,41 @@ func setupAutoPRTest(codeownersFile string, workingTree string) *internal.TestRo
 
 	return testOpts
 }
+
+func TestMain(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectedErr string
+		promptStubs func(*internal.MockPrompter)
+	}{
+		{
+			name:        "Test",
+			args:        []string{"report"},
+			expectedErr: "",
+			promptStubs: func(m *internal.MockPrompter) {
+
+			},
+		},
+	}
+
+	// TODO: Make use genuine file system and git
+	// but not gh or stdout, prompter
+	opts := &cmd.RootCmdOptions{}
+
+	// TODO: Do global setup
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// TODO: Do common test setup
+
+			// TODO: Do test specific setup
+			err := mainCore(opts, tt.args)
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tt.expectedErr, err)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -4,73 +4,30 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/justindbaur/gh-codeowners/cmd"
+	"github.com/justindbaur/gh-codeowners/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-type mockPrompter struct{ mock.Mock }
-
-func (p *mockPrompter) Input(prompt, defaultValue string) (string, error) {
-	args := p.Called(prompt, defaultValue)
-	return args.String(0), args.Error(1)
-}
-
-func (p *mockPrompter) Select(prompt, defaultValue string, options []string) (int, error) {
-	args := p.Called(prompt, defaultValue, options)
-	return args.Int(0), args.Error(1)
-}
-
-func (p *mockPrompter) Confirm(prompt string, defaultValue bool) (bool, error) {
-	args := p.Called(prompt, defaultValue)
-	return args.Bool(0), args.Error(1)
-}
-
-func newMockPrompter() *mockPrompter {
-	return &mockPrompter{}
-}
-
-type TestRootCmdOptions struct {
-	Mock     *mock.Mock
-	Prompter *mockPrompter
-	In       *bytes.Buffer
-	Out      *bytes.Buffer
-	Err      *bytes.Buffer
-}
-
-func (testOpts *TestRootCmdOptions) mockTemplateHole(team string, name string, value string) *mock.Call {
-	return testOpts.Prompter.Mock.On("Input", fmt.Sprintf("%s: %s", team, name), "").Return(value, nil)
-}
-
-func (testOpts *TestRootCmdOptions) mockCodeowners(codeownersContent []string) {
-	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").
-		Return(&cmd.File{
-			Reader: bytes.NewBufferString(strings.Join(codeownersContent, "\n")),
-			Close:  func() error { return nil },
-		}, nil)
-}
-
-func (testOpts *TestRootCmdOptions) mockWorkingDirectory(files []string) {
-	testOpts.Mock.
-		On("GitExec", []string{"--no-pager", "diff", "--name-only"}).
-		Return([]byte(strings.Join(files, "\n")), nil)
-}
-
-func (testOpts *TestRootCmdOptions) toActual() *cmd.RootCmdOptions {
+func toActual(testOpts *internal.TestRootCmdOptions) *cmd.RootCmdOptions {
 	return &cmd.RootCmdOptions{
 		In:  testOpts.In,
 		Out: testOpts.Out,
 		Err: testOpts.Err,
-		ReadFile: func(filePath string) (*cmd.File, error) {
+		ReadFile: func(filePath string) (cmd.File, error) {
 			args := testOpts.Mock.MethodCalled("ReadFile", filePath)
-			return args.Get(0).(*cmd.File), args.Error(1)
+			return args.Get(0).(cmd.File), args.Error(1)
 		},
 		GitExec: func(arg ...string) ([]byte, error) {
 			args := testOpts.Mock.MethodCalled("GitExec", arg)
 			return args.Get(0).([]byte), args.Error(1)
+		},
+		GitExecInt: func(arg ...string) error {
+			args := testOpts.Mock.MethodCalled("GitExecInt", arg)
+			return args.Error(0)
 		},
 		GhExec: func(arg ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
 			args := testOpts.Mock.MethodCalled("GhExec", arg)
@@ -88,29 +45,19 @@ func (testOpts *TestRootCmdOptions) toActual() *cmd.RootCmdOptions {
 	}
 }
 
-func newTestRootOpts() *TestRootCmdOptions {
-	return &TestRootCmdOptions{
-		In:       bytes.NewBuffer([]byte{}),
-		Out:      bytes.NewBuffer([]byte{}),
-		Err:      bytes.NewBuffer([]byte{}),
-		Mock:     &mock.Mock{},
-		Prompter: newMockPrompter(),
-	}
-}
-
 func TestMainCoreReport(t *testing.T) {
-	testOpts := newTestRootOpts()
+	testOpts := internal.NewTestRootOpts()
 
-	testOpts.mockCodeowners([]string{
+	testOpts.MockCodeowners([]string{
 		"test-dir @team-1",
 		"other-dir @team-2",
 	})
 
-	testOpts.mockWorkingDirectory([]string{
+	testOpts.MockWorkingDirectory([]string{
 		"test-dir/test-file.txt",
 	})
 
-	err := mainCore(testOpts.toActual(), []string{"report"})
+	err := mainCore(toActual(testOpts), []string{"report"})
 
 	// Assert things
 	assert.NoError(t, err)
@@ -118,14 +65,14 @@ func TestMainCoreReport(t *testing.T) {
 }
 
 func TestMainCoreStage(t *testing.T) {
-	testOpts := newTestRootOpts()
+	testOpts := internal.NewTestRootOpts()
 
-	testOpts.mockCodeowners([]string{
+	testOpts.MockCodeowners([]string{
 		"test-dir @team-1",
 		"other-dir @team-2",
 	})
 
-	testOpts.mockWorkingDirectory([]string{
+	testOpts.MockWorkingDirectory([]string{
 		"test-dir/test-file.txt",
 	})
 
@@ -133,7 +80,7 @@ func TestMainCoreStage(t *testing.T) {
 		On("GitExec", []string{"add", "test-dir/test-file.txt"}).
 		Return([]byte{}, nil)
 
-	err := mainCore(testOpts.toActual(), []string{"stage", "@team-1"})
+	err := mainCore(toActual(testOpts), []string{"stage", "@team-1"})
 
 	// Assert things
 	assert.NoError(t, err)
@@ -141,15 +88,15 @@ func TestMainCoreStage(t *testing.T) {
 }
 
 func TestMainCoreAutoPR(t *testing.T) {
-	testOpts := newTestRootOpts()
+	testOpts := internal.NewTestRootOpts()
 
 	testOpts.Prompter.On("Input", "What branch template do you want?", "").Return("branch-{{ .Input \"Safe Name\"}}", nil)
 	testOpts.Prompter.On("Input", "What commit/PR title template do you want?", "Files for {{ .TeamId }}").Return("Do work for {{ .Input \"Safe Name\" }}", nil)
 	testOpts.Prompter.On("Input", "Enter the path to the file containing your PR template", "./.github/PULL_REQUEST_TEMPLATE.md").Return("./.github/PULL_REQUEST_TEMPLATE.md", nil)
-	testOpts.mockTemplateHole("1", "Safe Name", "one")
-	testOpts.mockTemplateHole("2", "Safe Name", "two")
+	testOpts.MockTemplateHole("1", "Safe Name", "one")
+	testOpts.MockTemplateHole("2", "Safe Name", "two")
 
-	testOpts.mockCodeowners([]string{
+	testOpts.MockCodeowners([]string{
 		"test-dir @team-1",
 		"other-dir @team-2",
 	})
@@ -160,12 +107,11 @@ func TestMainCoreAutoPR(t *testing.T) {
 		"rev-parse",
 		"--show-toplevel"}).Return(fmt.Appendf(nil, "%s\n", tempDir), nil)
 
-	testOpts.Mock.On("ReadFile", "./.github/PULL_REQUEST_TEMPLATE.md").Return(&cmd.File{
-		Reader: bytes.NewBufferString("My PR template!"),
-		Close:  func() error { return nil },
+	testOpts.Mock.On("ReadFile", "./.github/PULL_REQUEST_TEMPLATE.md").Return(&internal.TestFile{
+		Contents: "My PR template!",
 	}, nil)
 
-	testOpts.mockWorkingDirectory([]string{
+	testOpts.MockWorkingDirectory([]string{
 		"test-dir/test-file.txt",
 		"other-dir/file.txt",
 	})
@@ -198,7 +144,7 @@ func TestMainCoreAutoPR(t *testing.T) {
 
 	testOpts.Mock.On("GitExec", []string{"checkout", "-"}).Return([]byte{}, nil)
 
-	err := mainCore(testOpts.toActual(), []string{"auto-pr"})
+	err := mainCore(toActual(testOpts), []string{"auto-pr"})
 
 	// Assert things
 	assert.NoError(t, err)
@@ -207,10 +153,10 @@ func TestMainCoreAutoPR(t *testing.T) {
 func TestMainCoreAutoPR_withArgsMakesTwoPRS(t *testing.T) {
 	opts := setupAutoPRTest("dir-1 @team-1\ndir-2 @team-2\n", "dir-1/test.txt\ndir-2/test.txt\n")
 
-	opts.mockTemplateHole("@team-1", "Team Name", "one")
-	opts.mockTemplateHole("@team-2", "Team Name", "two")
+	opts.MockTemplateHole("@team-1", "Team Name", "one")
+	opts.MockTemplateHole("@team-2", "Team Name", "two")
 
-	err := mainCore(opts.toActual(), []string{"auto-pr", "--draft", "--commit", "commit-{{ .Name }}", "--branch", "branch/{{ .Name }}"})
+	err := mainCore(toActual(opts), []string{"auto-pr", "--draft", "--commit", "commit-{{ .Name }}", "--branch", "branch/{{ .Name }}"})
 
 	opts.Mock.AssertNumberOfCalls(t, "GhExec", 2)
 
@@ -220,7 +166,7 @@ func TestMainCoreAutoPR_withArgsMakesTwoPRS(t *testing.T) {
 func TestMainCoreAutoPR_help(t *testing.T) {
 	opts := setupAutoPRTest("", "")
 
-	err := mainCore(opts.toActual(), []string{"auto-pr", "--help"})
+	err := mainCore(toActual(opts), []string{"auto-pr", "--help"})
 
 	assert.NoError(t, err)
 	helpOutput := opts.Out.String()
@@ -230,24 +176,22 @@ func TestMainCoreAutoPR_help(t *testing.T) {
 func TestMainCoreAutoPR_helpLong(t *testing.T) {
 	opts := setupAutoPRTest("", "")
 
-	err := mainCore(opts.toActual(), []string{"help", "auto-pr"})
+	err := mainCore(toActual(opts), []string{"help", "auto-pr"})
 
 	assert.NoError(t, err)
 	helpOutput := opts.Out.String()
 	assert.NotEmpty(t, helpOutput)
 }
 
-func setupAutoPRTest(codeownersFile string, workingTree string) *TestRootCmdOptions {
-	testOpts := newTestRootOpts()
+func setupAutoPRTest(codeownersFile string, workingTree string) *internal.TestRootCmdOptions {
+	testOpts := internal.NewTestRootOpts()
 
-	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").Return(&cmd.File{
-		Reader: bytes.NewBufferString(codeownersFile),
-		Close:  func() error { return nil },
+	testOpts.Mock.On("ReadFile", ".github/CODEOWNERS").Return(&internal.TestFile{
+		Contents: codeownersFile,
 	}, nil)
 
-	testOpts.Mock.On("ReadFile", "./.github/PULL_REQUEST_TEMPLATE.md").Return(&cmd.File{
-		Reader: bytes.NewBufferString("My PR template!"),
-		Close:  func() error { return nil },
+	testOpts.Mock.On("ReadFile", "./.github/PULL_REQUEST_TEMPLATE.md").Return(&internal.TestFile{
+		Contents: "My PR template!",
 	}, nil)
 
 	tempDir, _ := os.MkdirTemp("", "test")

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/cli/safeexec"
@@ -231,23 +233,72 @@ func setupAutoPRTest(codeownersFile string, workingTree string) *internal.TestRo
 	return testOpts
 }
 
+type TestFile struct {
+	name     string
+	contents string
+}
+
 func TestMain(t *testing.T) {
 	tests := []struct {
-		name        string
-		args        []string
-		expectedErr string
-		promptStubs func(*internal.MockPrompter)
-		assertOut   func(t *testing.T, out string)
+		name         string
+		args         []string
+		initialFiles []TestFile
+		updatedFiles []TestFile
+		expectedErr  string
+		promptStubs  func(*internal.MockPrompter)
+		assertOut    func(t *testing.T, out string)
 	}{
 		{
-			name:        "Test",
+			name:        "Simple Report",
 			args:        []string{"report"},
 			expectedErr: "",
 			promptStubs: func(m *internal.MockPrompter) {
 
 			},
+			initialFiles: []TestFile{
+				{
+					name:     ".github/CODEOWNERS",
+					contents: "*.txt @my-org/my-team",
+				},
+				{
+					name:     "file.txt",
+					contents: "yo!",
+				},
+			},
+			updatedFiles: []TestFile{
+				{
+					name:     "file.txt",
+					contents: "hello!",
+				},
+			},
 			assertOut: func(t *testing.T, out string) {
-				assert.Equal(t, "Files that are unowned: 1\n", out)
+				assert.Equal(t, "@my-org/my-team: 1\n", out)
+			},
+		},
+		{
+			name:        "Auto PR",
+			args:        []string{"auto-pr"},
+			expectedErr: "",
+			promptStubs: func(mp *internal.MockPrompter) {},
+			initialFiles: []TestFile{
+				{
+					name:     ".github/CODEOWNERS",
+					contents: "one @my-org/one\ntwo @my-org/two\n",
+				},
+			},
+			updatedFiles: []TestFile{
+				{
+					name:     "one/file.txt",
+					contents: "1",
+				},
+				{
+					name:     "two/file.txt",
+					contents: "2",
+				},
+				{
+					name:     "unowned.txt",
+					contents: "unowned!",
+				},
 			},
 		},
 	}
@@ -255,13 +306,52 @@ func TestMain(t *testing.T) {
 	gitBin, err := safeexec.LookPath("git")
 
 	if err != nil {
-		t.Fatal("Could not locate git.")
+		t.Fatalf("Could not locate git: %v", err)
 	}
 
 	// TODO: Do global setup
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			testDir, err := os.MkdirTemp("", "")
+			t.Logf("testDir: %s", testDir)
+			assert.NoError(t, err)
+			defer os.RemoveAll(testDir)
+
+			execGit := func(arg ...string) {
+				cmd := exec.Command(gitBin, arg...)
+				cmd.Dir = testDir
+				gitOutput, err := cmd.Output()
+				if err != nil {
+					assert.Fail(t, string(gitOutput))
+				}
+			}
+
+			execGit("init")
+
+			if tt.initialFiles != nil {
+				for _, file := range tt.initialFiles {
+					fullPath := path.Join(testDir, file.name)
+					os.MkdirAll(filepath.Dir(fullPath), os.ModePerm)
+					err = os.WriteFile(fullPath, []byte(file.contents), os.ModePerm)
+					assert.NoError(t, err)
+				}
+
+				execGit("add", ".")
+				execGit("commit", "--message", "Initial commit")
+			}
+
+			if tt.updatedFiles != nil {
+				for _, file := range tt.updatedFiles {
+					fullPath := path.Join(testDir, file.name)
+					assert.NoError(t, os.MkdirAll(filepath.Dir(fullPath), os.ModePerm))
+					assert.NoError(
+						t,
+						os.WriteFile(fullPath, []byte(file.contents), os.ModePerm),
+					)
+				}
+			}
+
 			mock := &mock.Mock{}
 
 			out := new(bytes.Buffer)
@@ -276,8 +366,17 @@ func TestMain(t *testing.T) {
 						return args.Get(0).([]byte), args.Error(1)
 					}
 
+					t.Logf("genuine git command: %s", arg)
+
 					// Genuine git
-					return exec.Command(gitBin, arg...).Output()
+					cmd := exec.Command(gitBin, arg...)
+					cmd.Dir = testDir
+					output, err := cmd.Output()
+					if err != nil {
+
+					}
+
+					return output, err
 				},
 				ReadFile: func(filePath string) (file cmd.File, err error) {
 					// Genuine file system
@@ -292,10 +391,8 @@ func TestMain(t *testing.T) {
 				Out: out,
 			}
 
-			// TODO: Do common test setup
-
-			// TODO: Do test specific setup
-			err := mainCore(opts, tt.args)
+			os.Chdir(testDir)
+			err = mainCore(opts, tt.args)
 			if tt.expectedErr == "" {
 				assert.NoError(t, err)
 

--- a/main_test.go
+++ b/main_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"testing"
 
+	"github.com/cli/safeexec"
 	"github.com/justindbaur/gh-codeowners/cmd"
 	"github.com/justindbaur/gh-codeowners/internal"
 	"github.com/stretchr/testify/assert"
@@ -106,6 +108,16 @@ func TestMainCoreAutoPR(t *testing.T) {
 	testOpts.Mock.On("GitExec", []string{
 		"rev-parse",
 		"--show-toplevel"}).Return(fmt.Appendf(nil, "%s\n", tempDir), nil)
+
+	testOpts.Mock.On("GitExec", []string{
+		"stash",
+		"push",
+	}).Return([]byte{}, nil)
+
+	testOpts.Mock.On("GitExec", []string{
+		"stash",
+		"pop",
+	}).Return([]byte{}, nil)
 
 	testOpts.Mock.On("ReadFile", "./.github/PULL_REQUEST_TEMPLATE.md").Return(&internal.TestFile{
 		Contents: "My PR template!",
@@ -225,6 +237,7 @@ func TestMain(t *testing.T) {
 		args        []string
 		expectedErr string
 		promptStubs func(*internal.MockPrompter)
+		assertOut   func(t *testing.T, out string)
 	}{
 		{
 			name:        "Test",
@@ -233,23 +246,62 @@ func TestMain(t *testing.T) {
 			promptStubs: func(m *internal.MockPrompter) {
 
 			},
+			assertOut: func(t *testing.T, out string) {
+				assert.Equal(t, "Files that are unowned: 1\n", out)
+			},
 		},
 	}
 
-	// TODO: Make use genuine file system and git
-	// but not gh or stdout, prompter
-	opts := &cmd.RootCmdOptions{}
+	gitBin, err := safeexec.LookPath("git")
+
+	if err != nil {
+		t.Fatal("Could not locate git.")
+	}
 
 	// TODO: Do global setup
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mock := &mock.Mock{}
+
+			out := new(bytes.Buffer)
+
+			// TODO: Make use genuine file system and git
+			// but not gh or stdout, prompter
+			opts := &cmd.RootCmdOptions{
+				GitExec: func(arg ...string) ([]byte, error) {
+					// Allow for an override
+					if mock.IsMethodCallable(t, "GitExec", arg) {
+						args := mock.MethodCalled("GitExec", arg)
+						return args.Get(0).([]byte), args.Error(1)
+					}
+
+					// Genuine git
+					return exec.Command(gitBin, arg...).Output()
+				},
+				ReadFile: func(filePath string) (file cmd.File, err error) {
+					// Genuine file system
+					actualFile, err := os.Open(filePath)
+
+					if err != nil {
+						return
+					}
+
+					return &RealFile{innerFile: actualFile}, nil
+				},
+				Out: out,
+			}
+
 			// TODO: Do common test setup
 
 			// TODO: Do test specific setup
 			err := mainCore(opts, tt.args)
 			if tt.expectedErr == "" {
 				assert.NoError(t, err)
+
+				if tt.assertOut != nil {
+					tt.assertOut(t, out.String())
+				}
 			} else {
 				assert.Equal(t, tt.expectedErr, err)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -268,7 +268,6 @@ func TestMain(t *testing.T) {
 
 	execGit := func(t *testing.T, arg ...string) {
 		cmd := exec.Command(gitBin, arg...)
-		cmd.WaitDelay = time.Duration(10) * time.Second
 		gitOutput, err := cmd.Output()
 		if err != nil {
 			assert.Fail(t, string(gitOutput))
@@ -282,6 +281,7 @@ func TestMain(t *testing.T) {
 		initialFiles []TestFile
 		updatedFiles []TestFile
 		expectedErr  string
+		preMock      func(m *mock.Mock)
 		promptStubs  func(*internal.MockPrompter)
 		assertOut    func(t *testing.T, out string)
 	}{
@@ -313,7 +313,7 @@ func TestMain(t *testing.T) {
 			},
 		},
 		{
-			name:        "Auto PR",
+			name:        "Auto PR with interactive staging",
 			args:        []string{"auto-pr", "--branch", "branch/{{ .Input \"Name\"}}", "--commit", "My Commit {{ .Input \"Name\"}}"},
 			expectedErr: "",
 			promptStubs: func(mp *internal.MockPrompter) {
@@ -335,11 +335,21 @@ func TestMain(t *testing.T) {
 					"one: Name",
 					"",
 				).Return("One", nil)
+
+				mp.On(
+					"Input",
+					"two: Name",
+					"",
+				).Return("Two", nil)
 			},
 			initialFiles: []TestFile{
 				{
 					name:     ".github/CODEOWNERS",
 					contents: "one @my-org/one\ntwo @my-org/two\n",
+				},
+				{
+					name:     "unowned.txt",
+					contents: "This is the first portion.\n\nStable\n\nStable\n\nStable\n\nThis is the second portion.\n",
 				},
 			},
 			updatedFiles: []TestFile{
@@ -353,8 +363,27 @@ func TestMain(t *testing.T) {
 				},
 				{
 					name:     "unowned.txt",
-					contents: "unowned!",
+					contents: "This is the first portion\n\nStable\n\nStable\n\nStable\n\nThis is the second portion\n",
 				},
+			},
+			preMock: func(m *mock.Mock) {
+				m.On("GitExecInt", mock.MatchedBy(func(args []string) bool {
+					return len(args) == 3 && args[0] == "add" && args[1] == "--patch"
+				})).Run(func(args mock.Arguments) {
+					file := args.Get(0).([]string)[2]
+					cmd := exec.Command(gitBin, "add", "--patch", file)
+					cmd.Stdin = bytes.NewReader([]byte("y\nn"))
+					assert.NoError(t, cmd.Run())
+				}).Once().Return(nil)
+
+				m.On("GitExecInt", mock.MatchedBy(func(args []string) bool {
+					return len(args) == 3 && args[0] == "add" && args[1] == "--patch"
+				})).Run(func(args mock.Arguments) {
+					file := args.Get(0).([]string)[2]
+					cmd := exec.Command(gitBin, "add", "--patch", file)
+					cmd.Stdin = bytes.NewReader([]byte("y"))
+					assert.NoError(t, cmd.Run())
+				}).Once().Return(nil)
 			},
 		},
 	}
@@ -368,6 +397,10 @@ func TestMain(t *testing.T) {
 			os.Chdir(testDir)
 			execGit(t, "init")
 
+			// I personally use a signing key based gpg signature and this breaks being able to run this test
+			// automatically, so I turn it off just for this repo
+			execGit(t, "config", "--local", "commit.gpgsign", "false")
+
 			if tt.initialFiles != nil {
 				for _, file := range tt.initialFiles {
 					fullPath := path.Join(testDir, file.name)
@@ -377,7 +410,7 @@ func TestMain(t *testing.T) {
 				}
 
 				execGit(t, "add", ".")
-				execGit(t, "commit", "--no-gpg-sign", "--message", "Initial commit")
+				execGit(t, "commit", "--message", "Initial commit")
 			}
 
 			if tt.updatedFiles != nil {
@@ -431,8 +464,8 @@ func TestMain(t *testing.T) {
 					return output, err
 				},
 				GitExecInt: func(arg ...string) error {
-					// TODO: Do something
-					return nil
+					args := testMock.MethodCalled("GitExecInt", arg)
+					return args.Error(0)
 				},
 				ReadFile: func(filePath string) (file cmd.File, err error) {
 					// Genuine file system
@@ -452,8 +485,18 @@ func TestMain(t *testing.T) {
 					return "origin", nil
 				},
 				GhExec: func(arg ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
-					return *bytes.NewBufferString(""), *bytes.NewBufferString(""), nil
+					if len(arg) == 8 && arg[0] == "pr" && arg[1] == "new" {
+						t.Logf("GhExec: %s", arg)
+						return *bytes.NewBufferString("https://github.com/fake-org/fake-repo/pulls/1"), *bytes.NewBufferString(""), nil
+					}
+
+					t.Logf("Unimplemented GhExec: %s", arg)
+					return *bytes.NewBufferString(""), *bytes.NewBufferString(""), fmt.Errorf("not implemented")
 				},
+			}
+
+			if tt.preMock != nil {
+				tt.preMock(testMock)
 			}
 
 			err = mainCore(opts, tt.args)

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,9 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cli/safeexec"
 	"github.com/justindbaur/gh-codeowners/cmd"
@@ -165,7 +167,7 @@ func TestMainCoreAutoPR(t *testing.T) {
 }
 
 func TestMainCoreAutoPR_withArgsMakesTwoPRS(t *testing.T) {
-	opts := setupAutoPRTest("dir-1 @team-1\ndir-2 @team-2\n", "dir-1/test.txt\ndir-2/test.txt\n")
+	opts := setupAutoPRTest("dir-1 @team-1\ndir-2 @team-2\n", "dir-1/test.txt\ndir-2/test.txt")
 
 	opts.MockTemplateHole("@team-1", "Team Name", "one")
 	opts.MockTemplateHole("@team-2", "Team Name", "two")
@@ -223,7 +225,7 @@ func setupAutoPRTest(codeownersFile string, workingTree string) *internal.TestRo
 		*contents = "My PR template!\nFor {slug}: {Team Name}"
 	}).Return(nil)
 
-	testOpts.Mock.On("GitExec", []string{"--no-pager", "diff", "--name-only"}).Return([]byte(workingTree), nil)
+	testOpts.MockWorkingDirectory(strings.Split(workingTree, "\n"))
 
 	// For anything else just pretend success
 	testOpts.Mock.On("GitExec", mock.Anything).Return([]byte{}, nil)
@@ -238,7 +240,42 @@ type TestFile struct {
 	contents string
 }
 
+type testWriter struct {
+	label string
+	buf   *bytes.Buffer
+	t     *testing.T
+}
+
+func (w *testWriter) Write(b []byte) (int, error) {
+	w.t.Logf("%s: %s", w.label, string(b))
+	return w.buf.Write(b)
+}
+
+func NewTestWriter(t *testing.T, label string) *testWriter {
+	return &testWriter{
+		t:     t,
+		label: label,
+		buf:   new(bytes.Buffer),
+	}
+}
+
 func TestMain(t *testing.T) {
+	gitBin, err := safeexec.LookPath("git")
+
+	if err != nil {
+		t.Fatalf("Could not locate git: %v", err)
+	}
+
+	execGit := func(t *testing.T, arg ...string) {
+		cmd := exec.Command(gitBin, arg...)
+		cmd.WaitDelay = time.Duration(10) * time.Second
+		gitOutput, err := cmd.Output()
+		if err != nil {
+			assert.Fail(t, string(gitOutput))
+		}
+		t.Logf("execGit (%s): %s", arg, string(gitOutput))
+	}
+
 	tests := []struct {
 		name         string
 		args         []string
@@ -277,9 +314,28 @@ func TestMain(t *testing.T) {
 		},
 		{
 			name:        "Auto PR",
-			args:        []string{"auto-pr"},
+			args:        []string{"auto-pr", "--branch", "branch/{{ .Input \"Name\"}}", "--commit", "My Commit {{ .Input \"Name\"}}"},
 			expectedErr: "",
-			promptStubs: func(mp *internal.MockPrompter) {},
+			promptStubs: func(mp *internal.MockPrompter) {
+				mp.On(
+					"Select",
+					"Choose where to put 1 unowned files",
+					"",
+					[]string{"@my-org/one", "@my-org/two", "Separate", "Choose for each"}).Return(3, nil)
+
+				mp.On(
+					"MultiSelect",
+					"What teams should 'unowned.txt' be put into (can select multiple)",
+					[]string{},
+					[]string{"@my-org/one", "@my-org/two", "Separate"},
+				).Return([]int{0, 1}, nil)
+
+				mp.On(
+					"Input",
+					"one: Name",
+					"",
+				).Return("One", nil)
+			},
 			initialFiles: []TestFile{
 				{
 					name:     ".github/CODEOWNERS",
@@ -303,31 +359,14 @@ func TestMain(t *testing.T) {
 		},
 	}
 
-	gitBin, err := safeexec.LookPath("git")
-
-	if err != nil {
-		t.Fatalf("Could not locate git: %v", err)
-	}
-
 	// TODO: Do global setup
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testDir, err := os.MkdirTemp("", "")
-			t.Logf("testDir: %s", testDir)
-			assert.NoError(t, err)
-			defer os.RemoveAll(testDir)
-
-			execGit := func(arg ...string) {
-				cmd := exec.Command(gitBin, arg...)
-				cmd.Dir = testDir
-				gitOutput, err := cmd.Output()
-				if err != nil {
-					assert.Fail(t, string(gitOutput))
-				}
-			}
-
-			execGit("init")
+			testDir := t.TempDir()
+			t.Logf("TestDir: %s", testDir)
+			os.Chdir(testDir)
+			execGit(t, "init")
 
 			if tt.initialFiles != nil {
 				for _, file := range tt.initialFiles {
@@ -337,8 +376,8 @@ func TestMain(t *testing.T) {
 					assert.NoError(t, err)
 				}
 
-				execGit("add", ".")
-				execGit("commit", "--message", "Initial commit")
+				execGit(t, "add", ".")
+				execGit(t, "commit", "--no-gpg-sign", "--message", "Initial commit")
 			}
 
 			if tt.updatedFiles != nil {
@@ -352,31 +391,48 @@ func TestMain(t *testing.T) {
 				}
 			}
 
-			mock := &mock.Mock{}
+			testMock := &mock.Mock{}
 
-			out := new(bytes.Buffer)
+			// We won't have an actual remote to push to
+			testMock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+				return len(args) == 4 && args[0] == "push" && args[1] == "--set-upstream" && args[2] == "origin"
+			})).Return([]byte{}, nil)
+
+			stdout := NewTestWriter(t, "out")
+			stderr := NewTestWriter(t, "err")
+
+			prompter := internal.NewMockPrompter()
+
+			if tt.promptStubs != nil {
+				tt.promptStubs(prompter)
+			}
 
 			// TODO: Make use genuine file system and git
 			// but not gh or stdout, prompter
 			opts := &cmd.RootCmdOptions{
 				GitExec: func(arg ...string) ([]byte, error) {
 					// Allow for an override
-					if mock.IsMethodCallable(t, "GitExec", arg) {
-						args := mock.MethodCalled("GitExec", arg)
+					if customIsMethodCallable(testMock, "GitExec", arg) {
+						args := testMock.MethodCalled("GitExec", arg)
 						return args.Get(0).([]byte), args.Error(1)
 					}
-
-					t.Logf("genuine git command: %s", arg)
 
 					// Genuine git
 					cmd := exec.Command(gitBin, arg...)
 					cmd.Dir = testDir
+					cmd.WaitDelay = time.Duration(10) * time.Second
 					output, err := cmd.Output()
 					if err != nil {
-
+						t.Logf("git (%s) error: %v\n%s", arg, err, output)
+					} else {
+						t.Logf("git (%s) success:\n%s", arg, output)
 					}
 
 					return output, err
+				},
+				GitExecInt: func(arg ...string) error {
+					// TODO: Do something
+					return nil
 				},
 				ReadFile: func(filePath string) (file cmd.File, err error) {
 					// Genuine file system
@@ -388,20 +444,50 @@ func TestMain(t *testing.T) {
 
 					return &RealFile{innerFile: actualFile}, nil
 				},
-				Out: out,
+				Out:      stdout,
+				Err:      stderr,
+				Prompter: prompter,
+				GetRemoteName: func() (string, error) {
+					// TODO: Do this genuinely?
+					return "origin", nil
+				},
+				GhExec: func(arg ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+					return *bytes.NewBufferString(""), *bytes.NewBufferString(""), nil
+				},
 			}
 
-			os.Chdir(testDir)
 			err = mainCore(opts, tt.args)
 			if tt.expectedErr == "" {
 				assert.NoError(t, err)
 
 				if tt.assertOut != nil {
-					tt.assertOut(t, out.String())
+					tt.assertOut(t, stdout.buf.String())
 				}
 			} else {
 				assert.Equal(t, tt.expectedErr, err)
 			}
 		})
 	}
+}
+
+// Ref: https://github.com/stretchr/testify/issues/1712
+func customIsMethodCallable(mock *mock.Mock, method string, arguments ...interface{}) bool {
+	for _, call := range mock.ExpectedCalls {
+		if call.Method != method {
+			continue
+		}
+
+		_, diffCount := call.Arguments.Diff(arguments)
+		if diffCount != 0 {
+			continue
+		}
+
+		if call.Repeatability < 0 {
+			return false
+		}
+
+		return true
+	}
+
+	return false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -114,14 +114,51 @@ func TestMainCoreAutoPR(t *testing.T) {
 		"--show-toplevel"}).Return(fmt.Appendf(nil, "%s\n", tempDir), nil)
 
 	testOpts.Mock.On("GitExec", []string{
+		"status",
+		"--porcelain",
+		"--untracked-files=all",
+	}).Return([]byte("?? remaining.txt\n"), nil).Once()
+
+	testOpts.Mock.On("GitExec", []string{
 		"stash",
 		"push",
+		"--include-untracked",
+		"-m",
+		"gh-codeowners:auto-pr:branch-one",
 	}).Return([]byte{}, nil)
 
 	testOpts.Mock.On("GitExec", []string{
 		"stash",
+		"list",
+		"--format=%gd\t%s",
+	}).Return([]byte("stash@{0}\tgh-codeowners:auto-pr:branch-one\n"), nil).Once()
+
+	testOpts.Mock.On("GitExec", []string{
+		"stash",
 		"pop",
+		"--index",
+		"stash@{0}",
+	}).Return([]byte{}, nil).Twice()
+
+	testOpts.Mock.On("GitExec", []string{
+		"stash",
+		"push",
+		"--include-untracked",
+		"-m",
+		"gh-codeowners:auto-pr:branch-two",
 	}).Return([]byte{}, nil)
+
+	testOpts.Mock.On("GitExec", []string{
+		"status",
+		"--porcelain",
+		"--untracked-files=all",
+	}).Return([]byte("?? remaining.txt\n"), nil).Once()
+
+	testOpts.Mock.On("GitExec", []string{
+		"stash",
+		"list",
+		"--format=%gd\t%s",
+	}).Return([]byte("stash@{0}\tgh-codeowners:auto-pr:branch-two\n"), nil).Once()
 
 	testOpts.Mock.On("ReadFile", "./.github/PULL_REQUEST_TEMPLATE.md").Return(&internal.TestFile{
 		Contents: "My PR template!",
@@ -187,6 +224,10 @@ func TestMainCoreAutoPR_help(t *testing.T) {
 	assert.NoError(t, err)
 	helpOutput := opts.Out.String()
 	assert.NotEmpty(t, helpOutput)
+	assert.Contains(t, helpOutput, "Available template values:")
+	assert.Contains(t, helpOutput, `.Input "Label"`)
+	assert.Contains(t, helpOutput, "Examples:")
+	assert.Contains(t, helpOutput, "--branch 'codeowners/{{ .Name }}'")
 }
 
 func TestMainCoreAutoPR_helpLong(t *testing.T) {
@@ -197,6 +238,8 @@ func TestMainCoreAutoPR_helpLong(t *testing.T) {
 	assert.NoError(t, err)
 	helpOutput := opts.Out.String()
 	assert.NotEmpty(t, helpOutput)
+	assert.Contains(t, helpOutput, "Go template for each PR body")
+	assert.Contains(t, helpOutput, "Team name or Separate for unowned files")
 }
 
 func setupAutoPRTest(codeownersFile string, workingTree string) *internal.TestRootCmdOptions {
@@ -284,6 +327,8 @@ func TestMain(t *testing.T) {
 		preMock      func(m *mock.Mock)
 		promptStubs  func(*internal.MockPrompter)
 		assertOut    func(t *testing.T, out string)
+		assertErr    func(t *testing.T, err error)
+		assertRepo   func(t *testing.T, testDir string, gitBin string)
 	}{
 		{
 			name:        "Simple Report",
@@ -310,6 +355,111 @@ func TestMain(t *testing.T) {
 			},
 			assertOut: func(t *testing.T, out string) {
 				assert.Equal(t, "@my-org/my-team: 1\n", out)
+			},
+		},
+		{
+			name:        "Report with multiple teams",
+			args:        []string{"report"},
+			expectedErr: "",
+			promptStubs: func(m *internal.MockPrompter) {},
+			initialFiles: []TestFile{
+				{
+					name:     ".github/CODEOWNERS",
+					contents: "*.go @my-org/backend\n*.js @my-org/frontend\n",
+				},
+				{name: "main.go", contents: "package main\n"},
+				{name: "app.js", contents: "console.log('hi');\n"},
+			},
+			updatedFiles: []TestFile{
+				{name: "main.go", contents: "package main // updated\n"},
+				{name: "app.js", contents: "console.log('updated');\n"},
+			},
+			assertOut: func(t *testing.T, out string) {
+				assert.Contains(t, out, "@my-org/backend: 1\n")
+				assert.Contains(t, out, "@my-org/frontend: 1\n")
+			},
+		},
+		{
+			name:        "Report with unowned files",
+			args:        []string{"report"},
+			expectedErr: "",
+			promptStubs: func(m *internal.MockPrompter) {},
+			initialFiles: []TestFile{
+				{
+					name:     ".github/CODEOWNERS",
+					contents: "*.go @my-org/backend\n",
+				},
+				{name: "main.go", contents: "package main\n"},
+				{name: "README.md", contents: "# Readme\n"},
+			},
+			updatedFiles: []TestFile{
+				{name: "main.go", contents: "package main // updated\n"},
+				{name: "README.md", contents: "# Updated\n"},
+			},
+			assertOut: func(t *testing.T, out string) {
+				assert.Contains(t, out, "@my-org/backend: 1\n")
+				assert.Contains(t, out, "Files that are unowned: 1\n")
+			},
+		},
+		{
+			name:        "Stage multiple files for a team",
+			args:        []string{"stage", "@my-org/backend"},
+			expectedErr: "",
+			promptStubs: func(m *internal.MockPrompter) {},
+			initialFiles: []TestFile{
+				{
+					name:     ".github/CODEOWNERS",
+					contents: "*.go @my-org/backend\n",
+				},
+				{name: "main.go", contents: "package main\n"},
+				{name: "server.go", contents: "package main\n"},
+				{name: "app.js", contents: "console.log();\n"},
+			},
+			updatedFiles: []TestFile{
+				{name: "main.go", contents: "package main // updated\n"},
+				{name: "server.go", contents: "package server // updated\n"},
+				{name: "app.js", contents: "console.log('updated');\n"},
+			},
+			assertOut: func(t *testing.T, out string) {
+				assert.Contains(t, out, "Staged: main.go\n")
+				assert.Contains(t, out, "Staged: server.go\n")
+				assert.NotContains(t, out, "app.js")
+			},
+		},
+		{
+			name:        "Stage with no matching team returns error",
+			args:        []string{"stage", "@my-org/nonexistent"},
+			promptStubs: func(m *internal.MockPrompter) {},
+			initialFiles: []TestFile{
+				{
+					name:     ".github/CODEOWNERS",
+					contents: "*.go @my-org/backend\n",
+				},
+				{name: "main.go", contents: "package main\n"},
+			},
+			updatedFiles: []TestFile{
+				{name: "main.go", contents: "package main // updated\n"},
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "did not find any files owned by '@my-org/nonexistent'")
+			},
+		},
+		{
+			name:        "Auto-PR fails when only one team would receive a PR",
+			args:        []string{"auto-pr", "--commit", "commit for {{ .TeamId }}", "--branch", "branch/{{ .TeamId }}"},
+			promptStubs: func(m *internal.MockPrompter) {},
+			initialFiles: []TestFile{
+				{
+					name:     ".github/CODEOWNERS",
+					contents: "*.go @my-org/backend\n",
+				},
+				{name: "main.go", contents: "package main\n"},
+			},
+			updatedFiles: []TestFile{
+				{name: "main.go", contents: "package main // updated\n"},
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "only one PR would be made")
 			},
 		},
 		{
@@ -386,6 +536,96 @@ func TestMain(t *testing.T) {
 				}).Once().Return(nil)
 			},
 		},
+		{
+			name: "Auto PR add failure recovers back to base branch",
+			args: []string{"auto-pr", "--branch", "branch/{{ .Name }}", "--commit", "My Commit {{ .Name }}"},
+			initialFiles: []TestFile{
+				{name: ".github/CODEOWNERS", contents: "one/ @my-org/one\ntwo/ @my-org/two\n"},
+				{name: "one/file.txt", contents: "one old\n"},
+				{name: "two/file.txt", contents: "two old\n"},
+			},
+			updatedFiles: []TestFile{
+				{name: "one/file.txt", contents: "one new\n"},
+				{name: "two/file.txt", contents: "two new\n"},
+			},
+			preMock: func(m *mock.Mock) {
+				m.On("GitExec", mock.MatchedBy(func(args []string) bool {
+					return len(args) >= 1 && args[0] == "add"
+				})).Once().Return([]byte{}, fmt.Errorf("permission denied"))
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "problem adding files")
+			},
+			assertRepo: func(t *testing.T, testDir string, gitBin string) {
+				currentBranch := strings.TrimSpace(mustGitOutput(t, testDir, gitBin, "branch", "--show-current"))
+				assert.NotEqual(t, "branch/one", currentBranch)
+				assert.NotEqual(t, "branch/two", currentBranch)
+				branches := mustGitOutput(t, testDir, gitBin, "branch", "--list")
+				assert.NotContains(t, branches, "branch/one")
+				assert.NotContains(t, branches, "branch/two")
+				status := mustGitOutput(t, testDir, gitBin, "status", "--short")
+				assert.Contains(t, status, " M one/file.txt")
+				assert.Contains(t, status, " M two/file.txt")
+			},
+		},
+		{
+			name: "Auto PR push failure keeps local recovery branch",
+			args: []string{"auto-pr", "--branch", "branch/{{ .Name }}", "--commit", "My Commit {{ .Name }}"},
+			initialFiles: []TestFile{
+				{name: ".github/CODEOWNERS", contents: "one/ @my-org/one\ntwo/ @my-org/two\n"},
+				{name: "one/file.txt", contents: "one old\n"},
+				{name: "two/file.txt", contents: "two old\n"},
+			},
+			updatedFiles: []TestFile{
+				{name: "one/file.txt", contents: "one new\n"},
+				{name: "two/file.txt", contents: "two new\n"},
+			},
+			preMock: func(m *mock.Mock) {
+				m.On("GitExec", mock.MatchedBy(func(args []string) bool {
+					return len(args) == 4 && args[0] == "push" && args[1] == "--set-upstream" && args[2] == "origin"
+				})).Once().Return([]byte{}, fmt.Errorf("remote rejected"))
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "problem pushing to remote")
+				assert.ErrorContains(t, err, "committed changes were left on branch")
+			},
+			assertRepo: func(t *testing.T, testDir string, gitBin string) {
+				currentBranch := strings.TrimSpace(mustGitOutput(t, testDir, gitBin, "branch", "--show-current"))
+				assert.NotEqual(t, "branch/one", currentBranch)
+				assert.NotEqual(t, "branch/two", currentBranch)
+				branches := mustGitOutput(t, testDir, gitBin, "branch", "--list")
+				assert.True(t, strings.Contains(branches, "branch/one") || strings.Contains(branches, "branch/two"))
+			},
+		},
+		{
+			name: "Auto PR gh failure keeps local recovery branch",
+			args: []string{"auto-pr", "--branch", "branch/{{ .Name }}", "--commit", "My Commit {{ .Name }}"},
+			initialFiles: []TestFile{
+				{name: ".github/CODEOWNERS", contents: "one/ @my-org/one\ntwo/ @my-org/two\n"},
+				{name: "one/file.txt", contents: "one old\n"},
+				{name: "two/file.txt", contents: "two old\n"},
+			},
+			updatedFiles: []TestFile{
+				{name: "one/file.txt", contents: "one new\n"},
+				{name: "two/file.txt", contents: "two new\n"},
+			},
+			preMock: func(m *mock.Mock) {
+				m.On("GhExec", mock.MatchedBy(func(args []string) bool {
+					return len(args) >= 2 && args[0] == "pr" && args[1] == "new"
+				})).Once().Return(*bytes.NewBufferString(""), *bytes.NewBufferString("rate limit"), fmt.Errorf("gh failed"))
+			},
+			assertErr: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "error creating PR with GitHub CLI")
+				assert.ErrorContains(t, err, "was left in place")
+			},
+			assertRepo: func(t *testing.T, testDir string, gitBin string) {
+				currentBranch := strings.TrimSpace(mustGitOutput(t, testDir, gitBin, "branch", "--show-current"))
+				assert.NotEqual(t, "branch/one", currentBranch)
+				assert.NotEqual(t, "branch/two", currentBranch)
+				branches := mustGitOutput(t, testDir, gitBin, "branch", "--list")
+				assert.True(t, strings.Contains(branches, "branch/one") || strings.Contains(branches, "branch/two"))
+			},
+		},
 	}
 
 	// TODO: Do global setup
@@ -425,11 +665,6 @@ func TestMain(t *testing.T) {
 			}
 
 			testMock := &mock.Mock{}
-
-			// We won't have an actual remote to push to
-			testMock.On("GitExec", mock.MatchedBy(func(args []string) bool {
-				return len(args) == 4 && args[0] == "push" && args[1] == "--set-upstream" && args[2] == "origin"
-			})).Return([]byte{}, nil)
 
 			stdout := NewTestWriter(t, "out")
 			stderr := NewTestWriter(t, "err")
@@ -485,6 +720,11 @@ func TestMain(t *testing.T) {
 					return "origin", nil
 				},
 				GhExec: func(arg ...string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+					if customIsMethodCallable(testMock, "GhExec", arg) {
+						args := testMock.MethodCalled("GhExec", arg)
+						return args.Get(0).(bytes.Buffer), args.Get(1).(bytes.Buffer), args.Error(2)
+					}
+
 					if len(arg) == 8 && arg[0] == "pr" && arg[1] == "new" {
 						t.Logf("GhExec: %s", arg)
 						return *bytes.NewBufferString("https://github.com/fake-org/fake-repo/pulls/1"), *bytes.NewBufferString(""), nil
@@ -499,18 +739,42 @@ func TestMain(t *testing.T) {
 				tt.preMock(testMock)
 			}
 
-			err = mainCore(opts, tt.args)
-			if tt.expectedErr == "" {
-				assert.NoError(t, err)
+			// We won't have an actual remote to push to
+			testMock.On("GitExec", mock.MatchedBy(func(args []string) bool {
+				return len(args) == 4 && args[0] == "push" && args[1] == "--set-upstream" && args[2] == "origin"
+			})).Return([]byte{}, nil)
 
-				if tt.assertOut != nil {
-					tt.assertOut(t, stdout.buf.String())
-				}
+			err = mainCore(opts, tt.args)
+			if tt.assertErr != nil {
+				tt.assertErr(t, err)
+			} else if tt.expectedErr == "" {
+				assert.NoError(t, err)
 			} else {
 				assert.Equal(t, tt.expectedErr, err)
 			}
+
+			if tt.assertOut != nil {
+				tt.assertOut(t, stdout.buf.String())
+			}
+
+			if tt.assertRepo != nil {
+				tt.assertRepo(t, testDir, gitBin)
+			}
 		})
 	}
+}
+
+func mustGitOutput(t *testing.T, testDir string, gitBin string, arg ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(gitBin, arg...)
+	cmd.Dir = testDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", arg, err, string(output))
+	}
+
+	return string(output)
 }
 
 // Ref: https://github.com/stretchr/testify/issues/1712

--- a/main_test.go
+++ b/main_test.go
@@ -640,6 +640,8 @@ func TestMain(t *testing.T) {
 			// I personally use a signing key based gpg signature and this breaks being able to run this test
 			// automatically, so I turn it off just for this repo
 			execGit(t, "config", "--local", "commit.gpgsign", "false")
+			execGit(t, "config", "--local", "user.name", "gh-codeowners test")
+			execGit(t, "config", "--local", "user.email", "gh-codeowners@example.com")
 
 			if tt.initialFiles != nil {
 				for _, file := range tt.initialFiles {


### PR DESCRIPTION
Gives a lot more customization of what to do with unowned files. Instead of only choosing to place them in their own PR or into another teams PR you can choose what to do with each one individually. If you choose to deal with them individually you can choose to have the file be split among multiple teams. If you choose this the tool will put you into interactive staging but if you don't like gits command line experience for this you can take that opportunity to jump into your own tool to do that and then come back and quit. 

Fixes #6

This changeset also adds a lot more recoverability to the process. To hopefully put you in a situation to run the operation again afterwards. 

I also made completions better. Whenever a team can be passed into a argument you can start typing the name and hit tab and it should give you a filtered list based on your codeowners file.

I also added a TON of tests to hopefully make this a still stable tool regardless of the amount of changes I made here.